### PR TITLE
Fix `isort` clashing with `black`

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,9 +1,5 @@
-[tool:isort]
-include_trailing_comma = True
-multi_line_output = 3
-line_length = 79
+[settings]
+profile = black
 known_first_party = data_pipelines_cli
 default_section = THIRDPARTY
-
-[settings]
 known_third_party = setuptools

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 
 - repo: https://github.com/pre-commit/mirrors-isort
-  rev: v4.3.21
+  rev: v5.9.3
   hooks:
     - id: isort
 
 - repo: https://github.com/psf/black
-  rev: stable
+  rev: 21.11b1
   hooks:
     - id: black
 
@@ -25,7 +25,7 @@ repos:
       ]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.910
+  rev: v0.910-1
   hooks:
     - id: mypy
       additional_dependencies:

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,8 @@ current_version = 0.0.0
 
 [flake8]
 exclude = .git,__pycache__,build,dist
-max-line-length = 79
+max-line-length = 88
+extend-ignore = E203
 
 [mypy]
 no_strict_optional = True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,8 +2,9 @@ import pathlib
 import unittest
 from unittest.mock import patch
 
-import data_pipelines_cli.cli as cli
 from click.testing import CliRunner
+
+import data_pipelines_cli.cli as cli
 from data_pipelines_cli.cli import DataPipelinesConfig, TemplateConfig
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,8 @@ commands=
 # Lint
 [flake8]
 exclude = .git,__pycache__,build,dist
-max-line-length = 79
+max-line-length = 88
+extend-ignore = E203
 
 [mypy]
 no_strict_optional = True


### PR DESCRIPTION
According to [this guide](https://github.com/psf/black/blob/main/docs/guides/using_black_with_other_tools.md), `black` tends to clash with both `isort` and `Flake8` when it comes to formatting. This commit fixes the problem by following the guide in the mentioned article, i.e. by setting `isort` configuration to be `black`-compatible and ignoring a whitespace warning in `Flake8`.

---
Keep in mind:
- [ ] Documentation updates
- [ ] [Changelog](CHANGELOG.md) updates