### PR TITLE
Fix docker tag bug preventing from correct pushing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix Docker SDK for Python's bug related to tagging, which prevented Docker from pushing images.
+
 ## [0.1.0] - 2021-12-01
 
 ### Added

--- a/data_pipelines_cli/cli_commands/compile.py
+++ b/data_pipelines_cli/cli_commands/compile.py
@@ -49,7 +49,7 @@ def _docker_build(docker_args: DockerArgs):
 
     echo_info("Building Docker image")
     docker_client = docker.from_env()
-    docker_tag = docker_args.docker_tag()
+    docker_tag = docker_args.docker_build_tag()
     _, logs_generator = docker_client.images.build(path=".", tag=docker_tag)
     click.echo(
         "".join(

--- a/data_pipelines_cli/cli_commands/deploy.py
+++ b/data_pipelines_cli/cli_commands/deploy.py
@@ -27,7 +27,7 @@ def _docker_push(docker_args: DockerArgs):
     docker_client = docker.from_env()
     for line in docker_client.images.push(
         repository=docker_args.repository,
-        tag=docker_args.docker_tag(),
+        tag=docker_args.commit_sha,
         stream=True,
     ):
         echo_subinfo(line)

--- a/data_pipelines_cli/data_structures.py
+++ b/data_pipelines_cli/data_structures.py
@@ -51,5 +51,5 @@ class DockerArgs:
             sys.exit(1)
         self.commit_sha = commit_sha
 
-    def docker_tag(self) -> str:
+    def docker_build_tag(self) -> str:
         return f"{self.repository}:{self.commit_sha}"


### PR DESCRIPTION
In Docker SDK for Python, `client.images.build` is accepting tags with colon (in the form of `repository:tag`) correctly, just like the Docker CLI. However, `client.images.push` expects explicit `repository` argument, thus its `tag` argument is supposed to be just the right-side of the colon, not the whole `repository:tag` expression.

---
Keep in mind:
- [ ] Documentation updates
- [X] [Changelog](CHANGELOG.md) updates