### PR TITLE
Add Google Cloud Storage emulator to test syncing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Added
 - `dp run` and `dp test` commands.
+- File synchronization tests for Google Cloud Storage using `gcp-storage-emulator`.
 
 ### Modified
 - `profiles.yml` gets generated and saved in `build` directory in `dp compile`, instead of relying on a local one in the

--- a/data_pipelines_cli/filesystem_utils.py
+++ b/data_pipelines_cli/filesystem_utils.py
@@ -22,7 +22,7 @@ class LocalRemoteSync:
         self.local_path_str = str(local_path).rstrip("/")
         self.local_fs = fsspec.filesystem("file")
         self.remote_fs, self.remote_path_str = fsspec.core.url_to_fs(
-            remote_path, **remote_kwargs
+            remote_path.rstrip("/"), **remote_kwargs
         )
         self._local_directory_suffixes = None
 

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ EXTRA_REQUIRE = {
         "pre-commit==2.15.0",
         "tox==3.21.1",
         "moto[s3]==2.2.16",
+        "gcp-storage-emulator==2021.12.2",
         *(
             [
                 require


### PR DESCRIPTION
File synchronization tests for Google Cloud Storage using `gcp-storage-emulator`. Google Cloud Storage mocks are very limited in comparison to `moto`, however those tests can provide at least some safety promises.

---
Keep in mind:
- [ ] Documentation updates
- [X] [Changelog](CHANGELOG.md) updates