### PR TITLE
Demo final touches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 ### Added
 - Add documentation in the style of [Read the Docs](https://readthedocs.org/).
 
+### Changed
+- `dp compile`:
+  - `--env` option has a default value: `local`,
+  - `--datahub` is changed to `--datahub-gms-uri`, `--repository` is changed to `--docker-repository-uri`.
+- `dp deploy`'s `--docker-push` is not a flag anymore and requires a Docker repository URI parameter; `--repository` got removed then.
+
 ## [0.6.0] - 2021-12-16
 
 ### Modified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Add documentation in the style of [Read the Docs](https://readthedocs.org/).
+- Exception classes in `errors.py`, deriving from `DataPipelinesError` base exception class.
 
 ### Changed
 - `dp compile`:
@@ -11,6 +12,8 @@
   - `--datahub` is changed to `--datahub-gms-uri`, `--repository` is changed to `--docker-repository-uri`.
 - `dp deploy`'s `--docker-push` is not a flag anymore and requires a Docker repository URI parameter; `--repository` got removed then.
 - `dp run` and `dp test` run `dbt deps` before actual **dbt** command.
+- Functions raise exceptions instead of exiting using `sys.exit(1)`; `cli.cli()` entrypoint is expecting exception and exits only there.
+- `dp deploy` raises an exception if there is no Docker image to push or `build/config/dag` directory does not exist.
 
 ## [0.6.0] - 2021-12-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - `--env` option has a default value: `local`,
   - `--datahub` is changed to `--datahub-gms-uri`, `--repository` is changed to `--docker-repository-uri`.
 - `dp deploy`'s `--docker-push` is not a flag anymore and requires a Docker repository URI parameter; `--repository` got removed then.
+- `dp run` and `dp test` run `dbt deps` before actual **dbt** command.
 
 ## [0.6.0] - 2021-12-16
 

--- a/data_pipelines_cli/cli.py
+++ b/data_pipelines_cli/cli.py
@@ -1,3 +1,5 @@
+import sys
+
 import click
 
 from .cli_commands.clean import clean_command
@@ -8,18 +10,28 @@ from .cli_commands.init import init_command
 from .cli_commands.run import run_command
 from .cli_commands.template import list_templates_command
 from .cli_commands.test import test_command
+from .cli_utils import echo_error
+from .errors import DataPipelinesError
 
 
 @click.group()
-def cli() -> None:
+def _cli() -> None:
     pass
 
 
-cli.add_command(clean_command)
-cli.add_command(compile_project_command)
-cli.add_command(create_command)
-cli.add_command(deploy_command)
-cli.add_command(init_command)
-cli.add_command(run_command)
-cli.add_command(list_templates_command)
-cli.add_command(test_command)
+def cli() -> None:
+    try:
+        _cli()
+    except DataPipelinesError as err:
+        echo_error(f"CLI Error: {err.message}")
+        sys.exit(1)
+
+
+_cli.add_command(clean_command)
+_cli.add_command(compile_project_command)
+_cli.add_command(create_command)
+_cli.add_command(deploy_command)
+_cli.add_command(init_command)
+_cli.add_command(run_command)
+_cli.add_command(list_templates_command)
+_cli.add_command(test_command)

--- a/data_pipelines_cli/cli_commands/compile.py
+++ b/data_pipelines_cli/cli_commands/compile.py
@@ -12,7 +12,12 @@ from ..cli_constants import (
     IMAGE_TAG_TO_REPLACE,
     INGEST_ENDPOINT_TO_REPLACE,
 )
-from ..cli_utils import echo_error, echo_info, get_argument_or_environment_variable
+from ..cli_utils import (
+    echo_error,
+    echo_info,
+    echo_warning,
+    get_argument_or_environment_variable,
+)
 from ..config_generation import (
     copy_config_dir_to_build_dir,
     copy_dag_dir_to_build_dir,
@@ -78,59 +83,81 @@ def _copy_dbt_manifest() -> None:
     )
 
 
-def _replace_datahub_address(datahub_address: str) -> None:
-    echo_info(f"Replacing INGEST_ENDPOINT with datahub address = {datahub_address}")
+def _try_replace_datahub_address(datahub_gms_uri: Optional[str]) -> None:
+    datahub_gms_uri = get_argument_or_environment_variable(
+        datahub_gms_uri, DATAHUB_URL_ENV
+    )
+    if not datahub_gms_uri:
+        echo_warning(
+            "'--datahub-gms-uri' argument not provided, "
+            f"{INGEST_ENDPOINT_TO_REPLACE} will not be replaced"
+        )
+        return
+
+    echo_info(
+        f"Replacing {INGEST_ENDPOINT_TO_REPLACE} with DataHub URI = {datahub_gms_uri}"
+    )
     replace(
         BUILD_DIR.joinpath("dag", "config", "base", "datahub.yml"),
         INGEST_ENDPOINT_TO_REPLACE,
-        datahub_address,
+        datahub_gms_uri,
     )
 
 
 def compile_project(
-    repository: Optional[str],
-    datahub: Optional[str],
+    docker_repository_uri: Optional[str],
+    datahub_gms_uri: Optional[str],
     docker_build: bool,
     env: str,
 ) -> None:
     """
     Create local working directories and build artifacts
 
-    :param repository: URI of the Docker repository
-    :type repository: Optional[str]
-    :param datahub: URI of the DataHub ingestion endpoint
-    :type datahub: Optional[str]
+    :param docker_repository_uri: URI of the Docker repository
+    :type docker_repository_uri: Optional[str]
+    :param datahub_gms_uri: URI of the DataHub ingestion endpoint
+    :type datahub_gms_uri: Optional[str]
     :param docker_build: Whether to build a Docker image
     :type docker_build: bool
     :param env: Name of the environment
     :type env: str
     """
-    datahub_address = get_argument_or_environment_variable(
-        datahub, "datahub", DATAHUB_URL_ENV
-    )
-    docker_args = DockerArgs(repository)
-
     copy_dag_dir_to_build_dir()
     copy_config_dir_to_build_dir()
 
+    docker_args = None
     k8s_config: pathlib.Path = BUILD_DIR.joinpath("dag", "config", "base", "k8s.yml")
-    _replace_image_tag(k8s_config, docker_args)
-    _replace_docker_repository_url(k8s_config, docker_args)
+    if docker_repository_uri:
+        docker_args = DockerArgs(docker_repository_uri)
+        _replace_image_tag(k8s_config, docker_args)
+        _replace_docker_repository_url(k8s_config, docker_args)
 
     _dbt_compile(env)
     _copy_dbt_manifest()
-    _replace_datahub_address(datahub_address)
+    _try_replace_datahub_address(datahub_gms_uri)
 
-    if docker_build:
+    if docker_build and docker_args:
         _docker_build(docker_args)
 
 
 @click.command(
-    name="compile", help="Create local working directories and build artifacts"
+    name="compile",
+    help="Create local working directories and build artifacts",
 )
-@click.option("--env", required=True, help="Name of the environment")
-@click.option("--repository", default=None, help="URI of the Docker repository")
-@click.option("--datahub", default=None, help="URI of the DataHub ingestion endpoint")
+@click.option(
+    "--env",
+    default="local",
+    type=str,
+    show_default=True,
+    required=True,
+    help="Name of the environment",
+)
+@click.option(
+    "--docker-repository-uri", default=None, help="URI of the Docker repository"
+)
+@click.option(
+    "--datahub-gms-uri", default=None, help="URI of the DataHub ingestion endpoint"
+)
 @click.option(
     "--docker-build",
     is_flag=True,
@@ -139,8 +166,8 @@ def compile_project(
 )
 def compile_project_command(
     env: str,
-    repository: Optional[str],
-    datahub: Optional[str],
+    docker_repository_uri: Optional[str],
+    datahub_gms_uri: Optional[str],
     docker_build: bool,
 ) -> None:
-    compile_project(repository, datahub, docker_build, env)
+    compile_project(docker_repository_uri, datahub_gms_uri, docker_build, env)

--- a/data_pipelines_cli/cli_commands/deploy.py
+++ b/data_pipelines_cli/cli_commands/deploy.py
@@ -30,13 +30,12 @@ class DeployCommand:
 
     def __init__(
         self,
-        repository: Optional[str],
+        docker_push: Optional[str],
         blob_address: str,
         provider_kwargs_dict: Dict[str, str],
-        docker_push: bool,
         datahub_ingest: bool,
     ):
-        self.docker_args = DockerArgs(repository) if docker_push else None
+        self.docker_args = DockerArgs(docker_push) if docker_push else None
         self.datahub_ingest = datahub_ingest
         self.blob_address_path = os.path.join(
             blob_address, "dags", DeployCommand._get_project_name()
@@ -114,13 +113,7 @@ class DeployCommand:
     help="Path to JSON or YAML file with arguments that should be passed to "
     "your Bucket/blob provider",
 )
-@click.option("--repository", default=None, help="Path to the Docker repository")
-@click.option(
-    "--docker-push",
-    is_flag=True,
-    default=False,
-    help="Whether to push a Docker image to the repository",
-)
+@click.option("--docker-push", default=None, help="Path to the Docker repository")
 @click.option(
     "--datahub-ingest",
     is_flag=True,
@@ -130,8 +123,7 @@ class DeployCommand:
 def deploy_command(
     address: str,
     blob_args: io.TextIOWrapper,
-    repository: Optional[str],
-    docker_push: bool,
+    docker_push: Optional[str],
     datahub_ingest: bool,
 ) -> None:
     try:
@@ -140,9 +132,8 @@ def deploy_command(
         provider_kwargs_dict = yaml.safe_load(blob_args)
 
     DeployCommand(
-        repository,
+        docker_push,
         address,
         provider_kwargs_dict,
-        docker_push,
         datahub_ingest,
     ).deploy()

--- a/data_pipelines_cli/cli_commands/init.py
+++ b/data_pipelines_cli/cli_commands/init.py
@@ -1,5 +1,4 @@
 import pathlib
-import sys
 import tempfile
 from typing import Optional, Sequence
 
@@ -10,6 +9,7 @@ import yaml
 
 from ..cli_constants import CONFIGURATION_PATH, DEFAULT_GLOBAL_CONFIG
 from ..data_structures import DataPipelinesConfig
+from ..errors import DataPipelinesError
 
 
 def _download_global_config(config_path: str) -> DataPipelinesConfig:
@@ -26,6 +26,7 @@ def init(config_path: Optional[str]) -> None:
 
     :param config_path: URI of the repository with a template of the config file
     :type config_path: Optional[str]
+    :raises DataPipelinesError: user do not want to overwrite existing config file
     """
     if CONFIGURATION_PATH.is_file():
         overwrite_confirm = questionary.confirm(
@@ -33,7 +34,7 @@ def init(config_path: Optional[str]) -> None:
             default=False,
         ).ask()
         if not overwrite_confirm:
-            sys.exit(1)
+            raise DataPipelinesError("Could not overwrite existing config")
 
     if config_path:
         config = _download_global_config(config_path)

--- a/data_pipelines_cli/cli_commands/run.py
+++ b/data_pipelines_cli/cli_commands/run.py
@@ -1,5 +1,6 @@
 import click
 
+from ..config_generation import generate_profiles_yml
 from ..dbt_utils import run_dbt_command
 
 
@@ -10,7 +11,9 @@ def run(env: str) -> None:
     :param env: Name of the environment
     :type env: str
     """
-    run_dbt_command(("run",), env, None)
+    profiles_path = generate_profiles_yml(env)
+    run_dbt_command(("deps",), env, profiles_path)
+    run_dbt_command(("run",), env, profiles_path)
 
 
 @click.command(name="run", help="Run the project on the local machine")

--- a/data_pipelines_cli/cli_commands/run.py
+++ b/data_pipelines_cli/cli_commands/run.py
@@ -14,6 +14,12 @@ def run(env: str) -> None:
 
 
 @click.command(name="run", help="Run the project on the local machine")
-@click.option("--env", default="local", type=str, help="Name of the environment")
+@click.option(
+    "--env",
+    default="local",
+    type=str,
+    show_default=True,
+    help="Name of the environment",
+)
 def run_command(env: str) -> None:
     run(env)

--- a/data_pipelines_cli/cli_commands/template.py
+++ b/data_pipelines_cli/cli_commands/template.py
@@ -1,12 +1,12 @@
 import click
 import yaml
 
-from data_pipelines_cli.data_structures import read_config_or_exit
+from data_pipelines_cli.data_structures import read_config_or_throw
 
 
 def list_templates() -> None:
     """Print a list of all templates saved in the config file"""
-    config = read_config_or_exit()
+    config = read_config_or_throw()
 
     click.echo("AVAILABLE TEMPLATES:\n")
     for tc in config["templates"].values():

--- a/data_pipelines_cli/cli_commands/test.py
+++ b/data_pipelines_cli/cli_commands/test.py
@@ -14,6 +14,12 @@ def test(env: str) -> None:
 
 
 @click.command(name="test", help="Run tests of the project on the local machine")
-@click.option("--env", default="local", type=str, help="Name of the environment")
+@click.option(
+    "--env",
+    default="local",
+    type=str,
+    show_default=True,
+    help="Name of the environment",
+)
 def test_command(env: str) -> None:
     test(env)

--- a/data_pipelines_cli/cli_commands/test.py
+++ b/data_pipelines_cli/cli_commands/test.py
@@ -1,5 +1,6 @@
 import click
 
+from ..config_generation import generate_profiles_yml
 from ..dbt_utils import run_dbt_command
 
 
@@ -10,7 +11,9 @@ def test(env: str) -> None:
     :param env: Name of the environment
     :type env: str
     """
-    run_dbt_command(("test",), env, None)
+    profiles_path = generate_profiles_yml(env)
+    run_dbt_command(("deps",), env, profiles_path)
+    run_dbt_command(("test",), env, profiles_path)
 
 
 @click.command(name="test", help="Run tests of the project on the local machine")

--- a/data_pipelines_cli/cli_utils.py
+++ b/data_pipelines_cli/cli_utils.py
@@ -53,6 +53,23 @@ def echo_subinfo(text: str, **kwargs: Any) -> None:
 
 
 def get_argument_or_environment_variable(
+    argument: Optional[str], environment_variable_name: str
+) -> Optional[str]:
+    """
+    Given *argument* is not `None`, returns its value. Otherwise, searches
+    for *environment_variable_name* amongst environment variables and returns
+    it.
+
+    :param argument: Optional value passed to the CLI as the *argument_name*
+    :type argument: Optional[str]
+    :param environment_variable_name: Name of the environment variable to search for
+    :type environment_variable_name: str
+    :return: Value of the *argument* or specified environment variable
+    """
+    return argument or os.environ.get(environment_variable_name)
+
+
+def get_argument_or_environment_variable_or_exit(
     argument: Optional[str], argument_name: str, environment_variable_name: str
 ) -> str:
     """
@@ -69,7 +86,7 @@ def get_argument_or_environment_variable(
     :type environment_variable_name: str
     :return: Value of the *argument* or specified environment variable
     """
-    result = argument or os.environ.get(environment_variable_name)
+    result = get_argument_or_environment_variable(argument, environment_variable_name)
     if not result:
         echo_error(
             f"Could not get {environment_variable_name}. Either set it as an "

--- a/data_pipelines_cli/data_structures.py
+++ b/data_pipelines_cli/data_structures.py
@@ -6,7 +6,7 @@ import yaml
 from data_pipelines_cli.cli_utils import (
     echo_error,
     echo_warning,
-    get_argument_or_environment_variable,
+    get_argument_or_environment_variable_or_exit,
 )
 from data_pipelines_cli.io_utils import git_revision_hash
 
@@ -78,9 +78,9 @@ class DockerArgs:
     commit_sha: str
     """Long hash of the current Git revision. Used as an image tag"""
 
-    def __init__(self, repository: Optional[str]):
-        self.repository = get_argument_or_environment_variable(
-            repository, "repository", "REPOSITORY_URL"
+    def __init__(self, docker_repository_uri: Optional[str]):
+        self.repository = get_argument_or_environment_variable_or_exit(
+            docker_repository_uri, "repository", "REPOSITORY_URL"
         )
         commit_sha = git_revision_hash()
         if not commit_sha:

--- a/data_pipelines_cli/data_structures.py
+++ b/data_pipelines_cli/data_structures.py
@@ -4,10 +4,10 @@ from typing import Dict, Optional
 import yaml
 
 from data_pipelines_cli.cli_utils import (
-    echo_error,
     echo_warning,
-    get_argument_or_environment_variable_or_exit,
+    get_argument_or_environment_variable_or_throw,
 )
+from data_pipelines_cli.errors import DataPipelinesError, NoConfigFileError
 from data_pipelines_cli.io_utils import git_revision_hash
 
 if sys.version_info >= (3, 8):
@@ -55,37 +55,40 @@ def read_config() -> Optional[DataPipelinesConfig]:
         return yaml.safe_load(f)
 
 
-def read_config_or_exit() -> DataPipelinesConfig:
+def read_config_or_throw() -> DataPipelinesConfig:
     """
-    Parses `.dp.yml` config file, if it exists. Otherwise, exits program with
-    a system exit status set to 1.
+    Parses `.dp.yml` config file, if it exists. Otherwise, raises
+    :exc:`.NoConfigFileError`
 
     :return: POD representing `.dp.yml` config file
     :rtype: DataPipelinesConfig
+    :raises NoConfigFileError: `.dp.yml` file not found
     """
 
     config = read_config()
     if not config:
-        sys.exit(1)
+        raise NoConfigFileError()
     return config
 
 
 class DockerArgs:
-    """Arguments required by the Docker to make a push to the repository"""
+    """Arguments required by the Docker to make a push to the repository
+
+    :raises DataPipelinesError: *repository* variable not set or git hash not found
+    """
 
     repository: str
     """URI of the Docker images repository"""
     commit_sha: str
     """Long hash of the current Git revision. Used as an image tag"""
 
-    def __init__(self, docker_repository_uri: Optional[str]):
-        self.repository = get_argument_or_environment_variable_or_exit(
+    def __init__(self, docker_repository_uri: Optional[str]) -> None:
+        self.repository = get_argument_or_environment_variable_or_throw(
             docker_repository_uri, "repository", "REPOSITORY_URL"
         )
         commit_sha = git_revision_hash()
         if not commit_sha:
-            echo_error("Could not get git revision hash.")
-            sys.exit(1)
+            raise DataPipelinesError("Could not get git revision hash.")
         self.commit_sha = commit_sha
 
     def docker_build_tag(self) -> str:

--- a/data_pipelines_cli/dbt_utils.py
+++ b/data_pipelines_cli/dbt_utils.py
@@ -1,15 +1,12 @@
 import pathlib
 import sys
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Tuple
 
 import yaml
 
 from .cli_constants import BUILD_DIR, get_dbt_profiles_env_name
 from .cli_utils import echo_subinfo, subprocess_run
-from .config_generation import (
-    generate_profiles_yml,
-    read_dictionary_from_config_directory,
-)
+from .config_generation import read_dictionary_from_config_directory
 from .data_structures import DataPipelinesConfig, read_config
 
 
@@ -23,7 +20,7 @@ def _read_dbt_vars_from_configs(dbt_env_config: Dict[str, Any]) -> str:
 
 
 def run_dbt_command(
-    command: Tuple[str, ...], env: str, profiles_path: Optional[pathlib.Path]
+    command: Tuple[str, ...], env: str, profiles_path: pathlib.Path
 ) -> None:
     """
     Runs dbt subprocess in a context of specified *env*
@@ -33,12 +30,11 @@ def run_dbt_command(
     :param env: Name of the environment
     :type env: str
     :param profiles_path: Path to the directory containing `profiles.yml` file
-    :type profiles_path: Optional[pathlib.Path]
+    :type profiles_path: pathlib.Path
     """
     command_str = " ".join(list(command))
     echo_subinfo(f"dbt {command_str}")
 
-    profiles_path = profiles_path or generate_profiles_yml(env)
     dbt_env_config = read_dictionary_from_config_directory(
         BUILD_DIR.joinpath("dag"), env, "dbt.yml"
     )

--- a/data_pipelines_cli/errors.py
+++ b/data_pipelines_cli/errors.py
@@ -1,0 +1,41 @@
+class DataPipelinesError(Exception):
+    """Base class for all exceptions in data_pipelines_cli module"""
+
+    message: str
+    """explanation of the error"""
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+
+
+class DependencyNotInstalledError(DataPipelinesError):
+    """Exception raised if certain dependency is not installed"""
+
+    def __init__(self, program_name: str) -> None:
+        self.message = (
+            f"'{program_name}' not installed. Run 'pip install "
+            f"data-pipelines-cli[{program_name}]'"
+        )
+
+
+class NoConfigFileError(DataPipelinesError):
+    """Exception raised if `.dp.yml` does not exist"""
+
+    def __init__(self) -> None:
+        self.message = "`.dp.yml` config file does not exists"
+
+
+class SubprocessNonZeroExitError(DataPipelinesError):
+    """Exception raised if subprocess exits with non-zero exit code"""
+
+    def __init__(self, subprocess_name: str, exit_code: int) -> None:
+        self.message = (
+            f"{subprocess_name} has exited with non-zero exit code: {exit_code}"
+        )
+
+
+class DockerNotInstalledError(DependencyNotInstalledError):
+    """Exception raised if 'docker' is not installed"""
+
+    def __init__(self) -> None:
+        super().__init__("docker")

--- a/data_pipelines_cli/filesystem_utils.py
+++ b/data_pipelines_cli/filesystem_utils.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import os
+import pathlib
 from typing import Dict, Set, Union
 
 import fsspec
 from fsspec import AbstractFileSystem
 
 from .cli_utils import echo_subinfo
+from .errors import DataPipelinesError
 
 
 class LocalRemoteSync:
@@ -25,7 +27,12 @@ class LocalRemoteSync:
         local_path: Union[str, os.PathLike[str]],
         remote_path: str,
         remote_kwargs: Dict[str, str],
-    ):
+    ) -> None:
+        if not pathlib.Path(local_path).exists():
+            raise DataPipelinesError(
+                f"{local_path} does not exists. Run 'dp compile' before."
+            )
+
         self.local_path_str = str(local_path).rstrip("/")
         self.local_fs = fsspec.filesystem("file")
         self.remote_fs, self.remote_path_str = fsspec.core.url_to_fs(

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -4,6 +4,6 @@ CLI Commands Reference
 If you are looking for extensive information on a specific CLI command,
 this part of the documentation is for you.
 
-.. click:: data_pipelines_cli.cli:cli
+.. click:: data_pipelines_cli.cli:_cli
    :prog: dp
    :nested: full

--- a/docs/source/data_pipelines_cli.rst
+++ b/docs/source/data_pipelines_cli.rst
@@ -65,6 +65,14 @@ data\_pipelines\_cli.dbt\_utils module
    :undoc-members:
    :show-inheritance:
 
+data\_pipelines\_cli.errors module
+----------------------------------
+
+.. automodule:: data_pipelines_cli.errors
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 data\_pipelines\_cli.filesystem\_utils module
 ---------------------------------------------
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,7 @@ from data_pipelines_cli.cli_constants import DEFAULT_GLOBAL_CONFIG
 from data_pipelines_cli.data_structures import (
     DataPipelinesConfig,
     TemplateConfig,
-    read_config_or_exit,
+    read_config_or_throw,
 )
 
 
@@ -36,7 +36,7 @@ class ConfigTestCase(unittest.TestCase):
             "data_pipelines_cli.cli_constants.CONFIGURATION_PATH",
             self.example_config_path,
         ):
-            self.assertEqual(self.example_config_dict, read_config_or_exit())
+            self.assertEqual(self.example_config_dict, read_config_or_throw())
 
     def test_list_templates(self):
         runner = CliRunner()
@@ -91,7 +91,7 @@ class InitTestCase(unittest.TestCase):
                 input="test_user\n/var/tmp",
             )
             self.assertEqual(0, result.exit_code)
-            self.assertEqual(self.example_config_dict, read_config_or_exit())
+            self.assertEqual(self.example_config_dict, read_config_or_throw())
 
     def test_global_config(self):
         runner = CliRunner()
@@ -104,4 +104,4 @@ class InitTestCase(unittest.TestCase):
         ):
             result = runner.invoke(init_command)
             self.assertEqual(0, result.exit_code)
-            self.assertEqual(DEFAULT_GLOBAL_CONFIG, read_config_or_exit())
+            self.assertEqual(DEFAULT_GLOBAL_CONFIG, read_config_or_throw())


### PR DESCRIPTION
* `dp compile` considers `local` as default env,
* `dp compile` without any arguments just run dbt-related build commands with `local` as env and does not require `--datahub` or `--repository` options to be set,
* `--datahub` is `--datahub-gms-uri`, `--repository` is `--docker-repository-uri`,
* `dp run` does not require calling `dp compile` — to be precise, it did not required it before either. However, right now it also calls `dbt deps` before calling actual command. Same applies to `dp test` too.
* `dp deploy` drops `--repository` option in favour of `--docker-push <repository_url>`; `--docker-push` is no longer a boolean flag.
* `dp deploy` has additional error messages.
* Instead of relying on `sys.exit(1)` inside arbitrary functions, now functions raises exceptions deriving from `DataPipelinesError` and the exception gets catched in the `cli()` entrypoint.

---
Keep in mind:
- [ ] Documentation updates
- [X] [Changelog](CHANGELOG.md) updates