### PR TITLE
Add a command for saving `profiles.yml` in $HOME

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -45,3 +45,6 @@ checks:
 plugins:
   pylint:
     enabled: true
+    checks:
+      import-error:
+        enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Exception classes in `errors.py`, deriving from `DataPipelinesError` base exception class.
 - Unit tests to massively improve code coverage.
 - `--version` flag to **dp** command.
+- Add `dp prepare-env` command that prepares local environment for standalone **dbt** (right now, it only generates and saves `profiles.yml` in `$HOME/.dbt`).
 
 ### Changed
 - `dp compile`:

--- a/data_pipelines_cli/cli.py
+++ b/data_pipelines_cli/cli.py
@@ -7,6 +7,7 @@ from .cli_commands.compile import compile_project_command
 from .cli_commands.create import create_command
 from .cli_commands.deploy import deploy_command
 from .cli_commands.init import init_command
+from .cli_commands.prepare_env import prepare_env_command
 from .cli_commands.run import run_command
 from .cli_commands.template import list_templates_command
 from .cli_commands.test import test_command
@@ -33,6 +34,7 @@ _cli.add_command(compile_project_command)
 _cli.add_command(create_command)
 _cli.add_command(deploy_command)
 _cli.add_command(init_command)
+_cli.add_command(prepare_env_command)
 _cli.add_command(run_command)
 _cli.add_command(list_templates_command)
 _cli.add_command(test_command)

--- a/data_pipelines_cli/cli_commands/compile.py
+++ b/data_pipelines_cli/cli_commands/compile.py
@@ -111,9 +111,9 @@ def _replace_k8s_settings(docker_args: DockerArgs) -> None:
 
 def compile_project(
     env: str,
-    docker_repository_uri: Optional[str],
-    datahub_gms_uri: Optional[str],
-    docker_build: bool,
+    docker_repository_uri: Optional[str] = None,
+    datahub_gms_uri: Optional[str] = None,
+    docker_build: bool = False,
 ) -> None:
     """
     Create local working directories and build artifacts

--- a/data_pipelines_cli/cli_commands/prepare_env.py
+++ b/data_pipelines_cli/cli_commands/prepare_env.py
@@ -1,0 +1,96 @@
+import os
+import pathlib
+from typing import Any, Dict
+
+import click
+import yaml
+from jinja2 import BaseLoader, DictLoader
+from jinja2.nativetypes import NativeEnvironment
+
+from data_pipelines_cli.cli_utils import echo_subinfo
+from data_pipelines_cli.config_generation import DbtProfile, generate_profiles_dict
+from data_pipelines_cli.dbt_utils import read_dbt_vars_from_configs
+from data_pipelines_cli.errors import JinjaVarKeyError
+
+
+def _prepare_jinja_replace_environment(
+    jinja_loader: BaseLoader, dbt_vars: Dict[str, Any]
+) -> NativeEnvironment:
+    def _jinja_vars(var_name: str) -> Any:
+        return dbt_vars[var_name]
+
+    def _jinja_env_vars(var_name: str) -> Any:
+        return os.environ[var_name]
+
+    jinja_env = NativeEnvironment(loader=jinja_loader)
+    # Hacking Jinja to use our functions, following:
+    # https://stackoverflow.com/a/6038550
+    jinja_env.globals["var"] = _jinja_vars
+    jinja_env.globals["env_var"] = _jinja_env_vars
+
+    return jinja_env
+
+
+def _replace_outputs_vars_with_values(
+    outputs_setting_dict: Dict[str, Any], dbt_vars: Dict[str, Any]
+) -> Dict[str, Any]:
+    jinja_loader = DictLoader(outputs_setting_dict)
+    jinja_env = _prepare_jinja_replace_environment(jinja_loader, dbt_vars)
+
+    rendered_settings = {}
+    for setting_key, setting_old_value in outputs_setting_dict.items():
+        try:
+            rendered_settings[setting_key] = jinja_env.get_template(
+                setting_key
+            ).render()
+        except TypeError:
+            # Jinja is accepting only str or Template and fails on int, etc.
+            rendered_settings[setting_key] = setting_old_value
+        except KeyError as key_error:
+            # Variable does not exist and _jinja_vars or _jinja_env_vars thrown
+            raise JinjaVarKeyError(key_error.args[0])
+    return rendered_settings
+
+
+def _replace_profiles_vars_with_values(
+    profile: Dict[str, DbtProfile], dbt_vars: Dict[str, Any]
+) -> Dict[str, DbtProfile]:
+    for targets_dict in profile.values():
+        new_outputs = {}
+        for target, settings_dict in targets_dict["outputs"].items():
+            new_outputs[target] = _replace_outputs_vars_with_values(
+                settings_dict, dbt_vars
+            )
+        targets_dict["outputs"] = new_outputs
+
+    return profile
+
+
+def prepare_env(env: str) -> None:
+    """
+    Prepares local environment for use with applications expecting a "traditional"
+    dbt structure, such as plugins to VS Code. If in doubt, use ``dp run`` and
+    ``dp test`` instead.
+
+    :param env: Name of the environment
+    :type env: str
+    """
+    profile = _replace_profiles_vars_with_values(
+        generate_profiles_dict(env, True), read_dbt_vars_from_configs(env)
+    )
+
+    home_profiles_path = pathlib.Path.home().joinpath(".dbt", "profiles.yml")
+    home_profiles_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(home_profiles_path, "w") as profiles:
+        yaml.dump(profile, profiles, default_flow_style=False)
+
+    echo_subinfo(f"Saved profiles.yml in {home_profiles_path}")
+
+
+@click.command(
+    name="prepare-env",
+    help="Prepare local environment for apps interfacing with dbt",
+)
+@click.option("--env", default="local", type=str, help="Name of the environment")
+def prepare_env_command(env: str) -> None:
+    prepare_env(env)

--- a/data_pipelines_cli/cli_commands/run.py
+++ b/data_pipelines_cli/cli_commands/run.py
@@ -1,6 +1,6 @@
 import click
 
-from ..config_generation import get_profiles_yml_path
+from ..config_generation import get_profiles_yml_build_path
 from ..dbt_utils import run_dbt_command
 from .compile import compile_project
 
@@ -12,8 +12,8 @@ def run(env: str) -> None:
     :param env: Name of the environment
     :type env: str
     """
-    compile_project(env, None, None, False)
-    profiles_path = get_profiles_yml_path(env)
+    compile_project(env)
+    profiles_path = get_profiles_yml_build_path(env)
     run_dbt_command(("run",), env, profiles_path)
 
 

--- a/data_pipelines_cli/cli_commands/test.py
+++ b/data_pipelines_cli/cli_commands/test.py
@@ -1,6 +1,6 @@
 import click
 
-from ..config_generation import get_profiles_yml_path
+from ..config_generation import get_profiles_yml_build_path
 from ..dbt_utils import run_dbt_command
 from .compile import compile_project
 
@@ -12,8 +12,8 @@ def test(env: str) -> None:
     :param env: Name of the environment
     :type env: str
     """
-    compile_project(env, None, None, False)
-    profiles_path = get_profiles_yml_path(env)
+    compile_project(env)
+    profiles_path = get_profiles_yml_build_path(env)
     run_dbt_command(("test",), env, profiles_path)
 
 

--- a/data_pipelines_cli/config_generation.py
+++ b/data_pipelines_cli/config_generation.py
@@ -94,7 +94,22 @@ class DbtProfile(TypedDict):
     """Dictionary of a warehouse data and credentials, referenced by `target` name"""
 
 
-def _generate_profile_dict(env: str) -> Dict[str, DbtProfile]:
+def generate_profiles_dict(env: str, copy_config_dir: bool) -> Dict[str, DbtProfile]:
+    """
+    Generates and saves ``profiles.yml`` file at ``build/profiles/local`` or
+    ``build/profiles/env_execution``, depending on `env` argument.
+
+    :param env: Name of the environment
+    :type env: str
+    :param copy_config_dir: Whether to copy ``config`` directory to ``build`` \
+        working directory
+    :type copy_config_dir: bool
+    :return: Dictionary representing data to be saved in ``profiles.yml``
+    :rtype: Dict[str, DbtProfile]
+    """
+    if copy_config_dir:
+        copy_config_dir_to_build_dir()
+
     dbt_env_config = read_dictionary_from_config_directory(
         BUILD_DIR.joinpath("dag"), env, "dbt.yml"
     )
@@ -121,7 +136,16 @@ def _generate_profile_dict(env: str) -> Dict[str, DbtProfile]:
     }
 
 
-def get_profiles_yml_path(env: str) -> pathlib.Path:
+def get_profiles_yml_build_path(env: str) -> pathlib.Path:
+    """
+    Returns path to ``build/profiles/<profile_name>/profiles.yml``,
+    depending on `env` argument.
+
+    :param env: Name of the environment
+    :type env: str
+    :return:
+    :rtype: pathlib.Path
+    """
     profile_name = get_dbt_profiles_env_name(env)
     return BUILD_DIR.joinpath("profiles", profile_name, "profiles.yml")
 
@@ -131,20 +155,21 @@ def generate_profiles_yml(env: str, copy_config_dir: bool = True) -> pathlib.Pat
     Generates and saves ``profiles.yml`` file at ``build/profiles/local`` or
     ``build/profiles/env_execution``, depending on `env` argument.
 
-    :param env: str
-    :param copy_config_dir: bool
+    :param env: Name of the environment
+    :type env: str
+    :param copy_config_dir: Whether to copy ``config`` directory to ``build`` \
+        working directory
+    :type copy_config_dir: bool
     :return: Path to ``build/profiles/{env}``
+    :rtype: pathlib.Path
     """
-    if copy_config_dir:
-        copy_config_dir_to_build_dir()
     echo_info("Generating profiles.yml")
-    profile = _generate_profile_dict(env)
+    profile = generate_profiles_dict(env, copy_config_dir)
 
-    profiles_path = get_profiles_yml_path(env)
+    profiles_path = get_profiles_yml_build_path(env)
     profiles_path.parent.mkdir(parents=True, exist_ok=True)
     with open(profiles_path, "w") as profiles:
         yaml.dump(profile, profiles, default_flow_style=False)
-
     echo_subinfo(f"Generated profiles.yml in {profiles_path}")
 
     return profiles_path.parent

--- a/data_pipelines_cli/dbt_utils.py
+++ b/data_pipelines_cli/dbt_utils.py
@@ -11,16 +11,34 @@ from .data_structures import DataPipelinesConfig, read_config
 from .errors import NoConfigFileError
 
 
-def _read_dbt_vars_from_configs(dbt_env_config: Dict[str, Any]) -> str:
+def read_dbt_vars_from_configs(env: str) -> Dict[str, Any]:
+    """
+    Reads `vars` field from dp configuration file (``$HOME/.dp.yml``), base
+    ``dbt.yml`` config (``config/base/dbt.yml``) and environment-specific config
+    (``config/{env}/dbt.yml``) and compiles into one dictionary.
+
+    :param env: Name of the environment
+    :type env: str
+    :return: Dictionary with `vars` and their keys
+    :rtype: Dict[str, Any]
+    """
+    dbt_env_config = read_dictionary_from_config_directory(
+        BUILD_DIR.joinpath("dag"), env, "dbt.yml"
+    )
+
     try:
         dp_config = read_config()
     except NoConfigFileError:
         dp_config = DataPipelinesConfig(templates={}, vars={})
     dp_vars = dp_config.get("vars", {})
     dbt_vars: Dict[str, str] = dbt_env_config.get("vars", {})
-    return yaml.dump(
-        dict(dp_vars, **dbt_vars), default_flow_style=True, width=sys.maxsize
-    )
+
+    return dict(dp_vars, **dbt_vars)
+
+
+def _dump_dbt_vars_from_configs_to_string(env: str) -> str:
+    dbt_vars = read_dbt_vars_from_configs(env)
+    return yaml.dump(dbt_vars, default_flow_style=True, width=sys.maxsize)
 
 
 def run_dbt_command(
@@ -44,7 +62,7 @@ def run_dbt_command(
     dbt_env_config = read_dictionary_from_config_directory(
         BUILD_DIR.joinpath("dag"), env, "dbt.yml"
     )
-    dbt_vars = _read_dbt_vars_from_configs(dbt_env_config)
+    dbt_vars = _dump_dbt_vars_from_configs_to_string(env)
     subprocess_run(
         [
             "dbt",

--- a/data_pipelines_cli/errors.py
+++ b/data_pipelines_cli/errors.py
@@ -51,3 +51,12 @@ class DockerNotInstalledError(DependencyNotInstalledError):
 
     def __init__(self) -> None:
         super().__init__("docker")
+
+
+class JinjaVarKeyError(DataPipelinesError):
+    def __init__(self, key: str) -> None:
+        self.message = (
+            f"Variable {key} cannot be found neither in 'dbt.yml' and "
+            "'$HOME/.dp.yml' vars nor in environment variables, causing Jinja "
+            "template rendering to fail."
+        )

--- a/docs/source/data_pipelines_cli.cli_commands.rst
+++ b/docs/source/data_pipelines_cli.cli_commands.rst
@@ -49,6 +49,14 @@ data\_pipelines\_cli.cli\_commands.init module
    :undoc-members:
    :show-inheritance:
 
+data\_pipelines\_cli.cli\_commands.prepare\_env module
+------------------------------------------------------
+
+.. automodule:: data_pipelines_cli.cli_commands.prepare_env
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 data\_pipelines\_cli.cli\_commands.run module
 ---------------------------------------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -165,6 +165,16 @@ case, you can try to run just the ``dp deploy "gs://<YOUR_GS_PATH>"`` command an
 Please refer to the documentation of the specific ``fsspec``'s implementation for more information about the required
 keyword arguments.
 
+Preparing dbt environment
+-------------------------
+
+Sometimes you would like to use standalone **dbt** or an application that interfaces with it (like VS Code plugin).
+``dp prepare-env`` prepares your local environment to be more conformant with a standalone **dbt** requirements, e.g.
+by saving ``profiles.yml`` in the home directory.
+
+However, be aware that most of the time you do not need to do so, and you can comfortably use ``dp run`` and ``dp test``
+commands to interface with the **dbt** instead.
+
 Clean project
 -------------
 

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ INSTALL_REQUIREMENTS = [
     "types-PyYAML>=6.0",
     "copier==5.1.0",
     "dbt>=0.21, <0.22",
+    "Jinja2>=2.11,<2.12",
     "fsspec",
 ]
 

--- a/tests/cli_commands/test_compile.py
+++ b/tests/cli_commands/test_compile.py
@@ -1,3 +1,4 @@
+import json
 import os
 import pathlib
 import tempfile
@@ -70,7 +71,7 @@ class CompileCommandTestCase(unittest.TestCase):
                 goldens_dir_path.joinpath("target", "manifest.json"), "r"
             ) as golden_manifest:
                 self.assertDictEqual(
-                    yaml.safe_load(golden_manifest), yaml.safe_load(tmp_manifest)
+                    json.load(golden_manifest), json.load(tmp_manifest)
                 )
             with open(
                 tmp_dir_path.joinpath("dag", "config", "base", "datahub.yml"), "r"

--- a/tests/cli_commands/test_prepare_env.py
+++ b/tests/cli_commands/test_prepare_env.py
@@ -1,0 +1,129 @@
+import pathlib
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import yaml
+from click.testing import CliRunner
+
+from data_pipelines_cli.cli import _cli
+from data_pipelines_cli.cli_commands.prepare_env import prepare_env
+from data_pipelines_cli.errors import JinjaVarKeyError
+
+
+class GenHomeProfilesCommandTestCase(unittest.TestCase):
+    goldens_dir_path = pathlib.Path(__file__).parent.parent.joinpath("goldens")
+    rendered_from_vars_profile = {
+        "bigquery": {
+            "target": "env_execution",
+            "outputs": {
+                "env_execution": {
+                    "method": "service-account",
+                    "project": "example-project",
+                    "dataset": "var21-dataset",
+                    "keyfile": "/tmp/a/b/c/d.json",
+                    "timeout_seconds": 150,
+                    "priority": "interactive",
+                    "location": "us-west1",
+                    "threads": 1337,
+                    "retries": 1,
+                    "type": "bigquery",
+                }
+            },
+        }
+    }
+
+    def setUp(self) -> None:
+        self.maxDiff = None
+
+    def test_no_var_profiles_generation(self):
+        runner = CliRunner()
+
+        with tempfile.TemporaryDirectory() as tmp_dir, patch(
+            "data_pipelines_cli.cli_constants.BUILD_DIR", pathlib.Path(tmp_dir)
+        ), patch(
+            "data_pipelines_cli.config_generation.BUILD_DIR",
+            pathlib.Path(tmp_dir),
+        ), patch(
+            "data_pipelines_cli.dbt_utils.BUILD_DIR",
+            pathlib.Path(tmp_dir),
+        ), patch(
+            "pathlib.Path.cwd", lambda: self.goldens_dir_path
+        ), tempfile.TemporaryDirectory() as tmp_dir2, patch(
+            "pathlib.Path.home", lambda: pathlib.Path(tmp_dir2)
+        ):
+            runner.invoke(_cli, ["prepare-env"])
+            with open(
+                pathlib.Path(tmp_dir2).joinpath(".dbt", "profiles.yml"), "r"
+            ) as generated, open(
+                self.goldens_dir_path.joinpath(
+                    "example_profiles", "local_snowflake.yml"
+                ),
+                "r",
+            ) as prepared:
+                self.assertDictEqual(
+                    yaml.safe_load(prepared), yaml.safe_load(generated)
+                )
+
+    def test_vars_profiles_generation(self):
+        with tempfile.TemporaryDirectory() as tmp_dir, patch(
+            "data_pipelines_cli.cli_constants.BUILD_DIR", pathlib.Path(tmp_dir)
+        ), patch(
+            "data_pipelines_cli.config_generation.BUILD_DIR",
+            pathlib.Path(tmp_dir),
+        ), patch(
+            "data_pipelines_cli.dbt_utils.BUILD_DIR",
+            pathlib.Path(tmp_dir),
+        ), patch.dict(
+            "os.environ", BIGQUERY_KEYFILE="/tmp/a/b/c/d.json"
+        ), patch(
+            "pathlib.Path.cwd", lambda: self.goldens_dir_path
+        ), tempfile.TemporaryDirectory() as tmp_dir2, patch(
+            "pathlib.Path.home", lambda: pathlib.Path(tmp_dir2)
+        ):
+            prepare_env("staging")
+
+            with open(
+                pathlib.Path(tmp_dir2).joinpath(".dbt", "profiles.yml"), "r"
+            ) as generated:
+                self.assertDictEqual(
+                    self.rendered_from_vars_profile, yaml.safe_load(generated)
+                )
+
+    def test_raise_missing_variable(self):
+        with tempfile.TemporaryDirectory() as tmp_dir, patch(
+            "data_pipelines_cli.cli_constants.BUILD_DIR", pathlib.Path(tmp_dir)
+        ), patch(
+            "data_pipelines_cli.config_generation.BUILD_DIR",
+            pathlib.Path(tmp_dir),
+        ), patch(
+            "data_pipelines_cli.cli_commands.prepare_env.read_dbt_vars_from_configs",
+            lambda _env: {},
+        ), patch.dict(
+            "os.environ", BIGQUERY_KEYFILE="/tmp/a/b/c/d.json"
+        ), patch(
+            "pathlib.Path.cwd", lambda: self.goldens_dir_path
+        ), tempfile.TemporaryDirectory() as tmp_dir2, patch(
+            "pathlib.Path.home", lambda: pathlib.Path(tmp_dir2)
+        ):
+            with self.assertRaises(JinjaVarKeyError):
+                prepare_env("staging")
+
+    def test_raise_missing_environment_variable(self):
+        with tempfile.TemporaryDirectory() as tmp_dir, patch(
+            "data_pipelines_cli.cli_constants.BUILD_DIR", pathlib.Path(tmp_dir)
+        ), patch(
+            "data_pipelines_cli.config_generation.BUILD_DIR",
+            pathlib.Path(tmp_dir),
+        ), patch(
+            "data_pipelines_cli.dbt_utils.BUILD_DIR",
+            pathlib.Path(tmp_dir),
+        ), patch.dict(
+            "os.environ", {}
+        ), patch(
+            "pathlib.Path.cwd", lambda: self.goldens_dir_path
+        ), tempfile.TemporaryDirectory() as tmp_dir2, patch(
+            "pathlib.Path.home", lambda: pathlib.Path(tmp_dir2)
+        ):
+            with self.assertRaises(JinjaVarKeyError):
+                prepare_env("staging")

--- a/tests/goldens/config/staging/bigquery.yml
+++ b/tests/goldens/config/staging/bigquery.yml
@@ -1,0 +1,9 @@
+method: service-account
+project: example-project
+dataset: "{{ var('variable_2') }}-dataset"
+threads: "{{ var('variable_1') }}"
+keyfile: "{{ env_var('BIGQUERY_KEYFILE') }}"
+timeout_seconds: 150
+priority: interactive
+location: us-west1
+retries: 1

--- a/tests/goldens/example_profiles/staging_bigquery.yml
+++ b/tests/goldens/example_profiles/staging_bigquery.yml
@@ -3,12 +3,12 @@ bigquery:
     env_execution:
       method: service-account
       project: example-project
-      dataset: example-dataset
-      keyfile: /var/keyfile.json
+      dataset: "{{ var('variable_2') }}-dataset"
+      keyfile: "{{ env_var('BIGQUERY_KEYFILE') }}"
       timeout_seconds: 150
       priority: interactive
       location: us-west1
-      threads: 1
+      threads: "{{ var('variable_1') }}"
       retries: 1
       type: bigquery
   target: env_execution

--- a/tests/test_dbt_utils.py
+++ b/tests/test_dbt_utils.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import yaml
 
-from data_pipelines_cli.dbt_utils import _read_dbt_vars_from_configs, run_dbt_command
+from data_pipelines_cli.dbt_utils import read_dbt_vars_from_configs, run_dbt_command
 from data_pipelines_cli.errors import NoConfigFileError
 
 
@@ -69,7 +69,7 @@ class DbtUtilsTest(unittest.TestCase):
             pathlib.Path(tmp_dir).joinpath("non_existing_config_file"),
         ):
             try:
-                result = _read_dbt_vars_from_configs({})
-                self.assertEqual("{}", result.rstrip())
+                result = read_dbt_vars_from_configs("env")
+                self.assertDictEqual({}, result)
             except NoConfigFileError:
                 self.fail("_read_dbt_vars_from_configs() raised NoConfigFileError!")


### PR DESCRIPTION
`dp gen-home-profiles` generates and saves `profiles.yml` in `$HOME/.dbt`.

---
Keep in mind:
- [X] Documentation updates
- [X] [Changelog](CHANGELOG.md) updates