### PR TITLE
Demo final touches, Part 2

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,47 @@
+version: "2"         # required to adjust maintainability checks
+
+checks:
+  argument-count:
+    enabled: true
+    config:
+      threshold: 4
+  complex-logic:
+    enabled: true
+    config:
+      threshold: 4
+  file-lines:
+    enabled: true
+    config:
+      threshold: 250
+  method-complexity:
+    enabled: true
+    config:
+      threshold: 5
+  method-count:
+    enabled: true
+    config:
+      threshold: 20
+  method-lines:
+    enabled: true
+    config:
+      threshold: 25
+  nested-control-flow:
+    enabled: true
+    config:
+      threshold: 4
+  return-statements:
+    enabled: true
+    config:
+      threshold: 4
+  similar-code:
+    enabled: true
+    config:
+      threshold: #language-specific defaults. overrides affect all languages.
+  identical-code:
+    enabled: true
+    config:
+      threshold: #language-specific defaults. overrides affect all languages.
+
 plugins:
   pylint:
     enabled: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,12 +25,23 @@ jobs:
           virtualenv venv
           source venv/bin/activate
           pip install --upgrade pip
+
       - name: Check pre-commit status
         run: |
           pip install .[tests]
           pip freeze
           pipdeptree
           pre-commit run --all-files
+
       - name: Test with tox
         run: |
           tox -e py37
+
+      - name: Report coverage
+        uses: paambaati/codeclimate-action@v2.7.5
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE }}
+        with:
+          coverageCommand: coverage xml
+          debug: true
+          coverageLocations: coverage.xml:coverage.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   - `--env` option has a default value: `base`,
   - `--datahub` is changed to `--datahub-gms-uri`, `--repository` is changed to `--docker-repository-uri`.
 - `dp deploy`'s `--docker-push` is not a flag anymore and requires a Docker repository URI parameter; `--repository` got removed then.
-- `dp run` and `dp test` run `dbt deps` before actual **dbt** command.
+- `dp run` and `dp test` run `dp compile` before actual **dbt** command.
 - Functions raise exceptions instead of exiting using `sys.exit(1)`; `cli.cli()` entrypoint is expecting exception and exits only there.
 - `dp deploy` raises an exception if there is no Docker image to push or `build/config/dag` directory does not exist.
 - Rename `gcp` to `gcs` in requirements (now one should run `pip install data-pipelines-cli[gcs]`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add documentation in the style of [Read the Docs](https://readthedocs.org/).
 - Exception classes in `errors.py`, deriving from `DataPipelinesError` base exception class.
 - Unit tests to massively improve code coverage.
+- `--version` flag to **dp** command.
 
 ### Changed
 - `dp compile`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Changed
 - `dp compile`:
-  - `--env` option has a default value: `local`,
+  - `--env` option has a default value: `base`,
   - `--datahub` is changed to `--datahub-gms-uri`, `--repository` is changed to `--docker-repository-uri`.
 - `dp deploy`'s `--docker-push` is not a flag anymore and requires a Docker repository URI parameter; `--repository` got removed then.
 - `dp run` and `dp test` run `dbt deps` before actual **dbt** command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `dp run` and `dp test` run `dbt deps` before actual **dbt** command.
 - Functions raise exceptions instead of exiting using `sys.exit(1)`; `cli.cli()` entrypoint is expecting exception and exits only there.
 - `dp deploy` raises an exception if there is no Docker image to push or `build/config/dag` directory does not exist.
+- Rename `gcp` to `gcs` in requirements (now one should run `pip install data-pipelines-cli[gcs]`).
 
 ## [0.6.0] - 2021-12-16
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 CLI for data platform
 
+**Read the full documentation at [https://data-pipelines-cli.readthedocs.io/](https://data-pipelines-cli.readthedocs.io/en/latest/index.html).**
+
 ## Installation
 Use the package manager [pip](https://pip.pypa.io/en/stable/) to install [dp (data-pipelines-cli)](https://pypi.org/project/data-pipelines-cli/):
 
@@ -39,12 +41,15 @@ directly to a template repository. If `<LINK_TO_TEMPLATE_REPOSITORY>` proves to 
 ### Project deployment
 
 `dp deploy` will sync with your bucket provider. The provider will be chosen automatically based on the remote URL.
-`dp deploy` also requires the user to point to JSON or YAML file with provider-specific data like access tokens or project
+Usually, it is worth pointing `dp deploy` to JSON or YAML file with provider-specific data like access tokens or project
 names. E.g., to connect with Google Cloud Storage, one should run:
 ```bash
 echo '{"token": "<PATH_TO_YOUR_TOKEN>", "project_name": "<YOUR_PROJECT_NAME>"}' > gs_args.json
 dp deploy "gs://<YOUR_GS_PATH>" --blob-args gs_args.json
 ```
+However, in some cases you do not need to do so, e.g. when using `gcloud` with properly set local credentials. In such
+case, you can try to run just the `dp deploy "gs://<YOUR_GS_PATH>"` command. Please refer to
+[documentation](https://data-pipelines-cli.readthedocs.io/en/latest/usage.html#project-deployment) for more information.
 
 When finished, call `dp clean` to remove compilation related directories.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ CLI for data platform
 Use the package manager [pip](https://pip.pypa.io/en/stable/) to install [dp (data-pipelines-cli)](https://pypi.org/project/data-pipelines-cli/):
 
 ```bash
-pip install data-pipelines-cli[docker,datahub,gcp]
+pip install data-pipelines-cli[docker,datahub,gcs]
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
 # data-pipelines-cli
 
+[![Python Version](https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9-blue.svg)](https://github.com/getindata/data-pipelines-cli)
+[![PyPI Version](https://badge.fury.io/py/data-pipelines-cli.svg)](https://pypi.org/project/data-pipelines-cli/)
+[![Downloads](https://pepy.tech/badge/data-pipelines-cli)](https://pepy.tech/project/data-pipelines-cli)
+[![Maintainability](https://api.codeclimate.com/v1/badges/e44ed9383a42b59984f6/maintainability)](https://codeclimate.com/github/getindata/data-pipelines-cli/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/e44ed9383a42b59984f6/test_coverage)](https://codeclimate.com/github/getindata/data-pipelines-cli/test_coverage)
+[![Documentation Status](https://readthedocs.org/projects/data-pipelines-cli/badge/?version=latest)](https://data-pipelines-cli.readthedocs.io/en/latest/?badge=latest)
+
 CLI for data platform
 
-**Read the full documentation at [https://data-pipelines-cli.readthedocs.io/](https://data-pipelines-cli.readthedocs.io/en/latest/index.html).**
+## Documentation
+
+Read the full documentation at [https://data-pipelines-cli.readthedocs.io/](https://data-pipelines-cli.readthedocs.io/en/latest/index.html)
 
 ## Installation
 Use the package manager [pip](https://pip.pypa.io/en/stable/) to install [dp (data-pipelines-cli)](https://pypi.org/project/data-pipelines-cli/):

--- a/data_pipelines_cli/cli.py
+++ b/data_pipelines_cli/cli.py
@@ -15,6 +15,7 @@ from .errors import DataPipelinesError
 
 
 @click.group()
+@click.version_option(prog_name="dp")
 def _cli() -> None:
     pass
 

--- a/data_pipelines_cli/cli_commands/compile.py
+++ b/data_pipelines_cli/cli_commands/compile.py
@@ -110,22 +110,22 @@ def _replace_k8s_settings(docker_args: DockerArgs) -> None:
 
 
 def compile_project(
+    env: str,
     docker_repository_uri: Optional[str],
     datahub_gms_uri: Optional[str],
     docker_build: bool,
-    env: str,
 ) -> None:
     """
     Create local working directories and build artifacts
 
+    :param env: Name of the environment
+    :type env: str
     :param docker_repository_uri: URI of the Docker repository
     :type docker_repository_uri: Optional[str]
     :param datahub_gms_uri: URI of the DataHub ingestion endpoint
     :type datahub_gms_uri: Optional[str]
     :param docker_build: Whether to build a Docker image
     :type docker_build: bool
-    :param env: Name of the environment
-    :type env: str
     :raises DataPipelinesError:
     """
     copy_dag_dir_to_build_dir()
@@ -150,7 +150,7 @@ def compile_project(
 )
 @click.option(
     "--env",
-    default="local",
+    default="base",
     type=str,
     show_default=True,
     required=True,
@@ -174,4 +174,4 @@ def compile_project_command(
     datahub_gms_uri: Optional[str],
     docker_build: bool,
 ) -> None:
-    compile_project(docker_repository_uri, datahub_gms_uri, docker_build, env)
+    compile_project(env, docker_repository_uri, datahub_gms_uri, docker_build)

--- a/data_pipelines_cli/cli_commands/run.py
+++ b/data_pipelines_cli/cli_commands/run.py
@@ -1,7 +1,8 @@
 import click
 
-from ..config_generation import generate_profiles_yml
+from ..config_generation import get_profiles_yml_path
 from ..dbt_utils import run_dbt_command
+from .compile import compile_project
 
 
 def run(env: str) -> None:
@@ -11,8 +12,8 @@ def run(env: str) -> None:
     :param env: Name of the environment
     :type env: str
     """
-    profiles_path = generate_profiles_yml(env)
-    run_dbt_command(("deps",), env, profiles_path)
+    compile_project(env, None, None, False)
+    profiles_path = get_profiles_yml_path(env)
     run_dbt_command(("run",), env, profiles_path)
 
 

--- a/data_pipelines_cli/cli_commands/test.py
+++ b/data_pipelines_cli/cli_commands/test.py
@@ -1,7 +1,8 @@
 import click
 
-from ..config_generation import generate_profiles_yml
+from ..config_generation import get_profiles_yml_path
 from ..dbt_utils import run_dbt_command
+from .compile import compile_project
 
 
 def test(env: str) -> None:
@@ -11,8 +12,8 @@ def test(env: str) -> None:
     :param env: Name of the environment
     :type env: str
     """
-    profiles_path = generate_profiles_yml(env)
-    run_dbt_command(("deps",), env, profiles_path)
+    compile_project(env, None, None, False)
+    profiles_path = get_profiles_yml_path(env)
     run_dbt_command(("test",), env, profiles_path)
 
 

--- a/data_pipelines_cli/cli_utils.py
+++ b/data_pipelines_cli/cli_utils.py
@@ -81,7 +81,7 @@ def get_argument_or_environment_variable(
         raise DataPipelinesError(
             f"Could not get {environment_variable_name}. Either set it as an "
             f"environment variable {environment_variable_name} or pass as a "
-            f"`--{argument_name}` CLI argument"
+            f"`--{argument_name}` CLI argument."
         )
     return result
 

--- a/data_pipelines_cli/config_generation.py
+++ b/data_pipelines_cli/config_generation.py
@@ -121,6 +121,11 @@ def _generate_profile_dict(env: str) -> Dict[str, DbtProfile]:
     }
 
 
+def get_profiles_yml_path(env: str) -> pathlib.Path:
+    profile_name = get_dbt_profiles_env_name(env)
+    return BUILD_DIR.joinpath("profiles", profile_name, "profiles.yml")
+
+
 def generate_profiles_yml(env: str, copy_config_dir: bool = True) -> pathlib.Path:
     """
     Generates and saves ``profiles.yml`` file at ``build/profiles/local`` or
@@ -135,8 +140,7 @@ def generate_profiles_yml(env: str, copy_config_dir: bool = True) -> pathlib.Pat
     echo_info("Generating profiles.yml")
     profile = _generate_profile_dict(env)
 
-    profile_name = get_dbt_profiles_env_name(env)
-    profiles_path = BUILD_DIR.joinpath("profiles", profile_name, "profiles.yml")
+    profiles_path = get_profiles_yml_path(env)
     profiles_path.parent.mkdir(parents=True, exist_ok=True)
     with open(profiles_path, "w") as profiles:
         yaml.dump(profile, profiles, default_flow_style=False)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,27 @@
 ``data-pipelines-cli``: CLI for data platform
 ==============================================
 
+.. image:: https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9-blue.svg
+   :target: https://github.com/getindata/data-pipelines-cli
+   :alt: Python Version
+
+.. image:: https://badge.fury.io/py/data-pipelines-cli.svg
+   :target: https://pypi.org/project/data-pipelines-cli/
+   :alt: PyPI Version
+
+.. image:: https://pepy.tech/badge/data-pipelines-cli
+   :target: https://pepy.tech/project/data-pipelines-cli
+   :alt: Downloads
+
+.. image:: https://api.codeclimate.com/v1/badges/e44ed9383a42b59984f6/maintainability
+   :target: https://codeclimate.com/github/getindata/data-pipelines-cli/maintainability
+   :alt: Maintainability
+
+.. image:: https://api.codeclimate.com/v1/badges/e44ed9383a42b59984f6/test_coverage
+   :target: https://codeclimate.com/github/getindata/data-pipelines-cli/test_coverage
+   :alt: Test Coverage
+
+
 Installation
 ------------
 Use the package manager `pip <https://pip.pypa.io/en/stable/>`_ to

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -148,7 +148,12 @@ Project deployment
 
 ``dp deploy`` will sync with your bucket provider. The provider will be chosen automatically based on the remote URL.
 ``dp deploy`` also requires the user to point to JSON or YAML file with provider-specific data like access tokens or project
-names. E.g., to connect with Google Cloud Storage, one should run:
+names. The *provider-specific data* should be interpreted as the ``**kwargs`` (keyword arguments) expected by a specific
+`fsspec <https://filesystem-spec.readthedocs.io/en/latest/>`_'s FileSystem implementation. One would most likely want to
+look at the `S3FileSystem <https://s3fs.readthedocs.io/en/latest/api.html#s3fs.core.S3FileSystem>`_ or
+`GCSFileSystem <https://gcsfs.readthedocs.io/en/latest/api.html#gcsfs.core.GCSFileSystem>`_ documentation.
+
+E.g., to connect with Google Cloud Storage, one should run:
 
 .. code-block:: bash
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -147,7 +147,7 @@ Project deployment
 ------------------
 
 ``dp deploy`` will sync with your bucket provider. The provider will be chosen automatically based on the remote URL.
-``dp deploy`` also requires the user to point to JSON or YAML file with provider-specific data like access tokens or project
+Usually, it is worth pointing ``dp deploy`` to a JSON or YAML file with provider-specific data like access tokens or project
 names. The *provider-specific data* should be interpreted as the ``**kwargs`` (keyword arguments) expected by a specific
 `fsspec <https://filesystem-spec.readthedocs.io/en/latest/>`_'s FileSystem implementation. One would most likely want to
 look at the `S3FileSystem <https://s3fs.readthedocs.io/en/latest/api.html#s3fs.core.S3FileSystem>`_ or
@@ -159,6 +159,11 @@ E.g., to connect with Google Cloud Storage, one should run:
 
  echo '{"token": "<PATH_TO_YOUR_TOKEN>", "project_name": "<YOUR_PROJECT_NAME>"}' > gs_args.json
  dp deploy "gs://<YOUR_GS_PATH>" --blob-args gs_args.json
+
+However, in some cases you do not need to do so, e.g. when using **gcloud** with properly set local credentials. In such
+case, you can try to run just the ``dp deploy "gs://<YOUR_GS_PATH>"`` command and let ``gcsfs`` search for the credentials.
+Please refer to the documentation of the specific ``fsspec``'s implementation for more information about the required
+keyword arguments.
 
 Clean project
 -------------

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ INSTALL_REQUIREMENTS = [
 ]
 
 EXTRA_FILESYSTEMS_REQUIRE = {
-    "gcp": ["gcsfs"],
+    "gcs": ["gcsfs"],
     "s3": ["s3fs"],
 }
 

--- a/tests/cli_commands/test_run_test.py
+++ b/tests/cli_commands/test_run_test.py
@@ -30,6 +30,9 @@ class RunTestCommandTestCase(unittest.TestCase):
             ), tempfile.TemporaryDirectory() as tmp_dir, patch(
                 "data_pipelines_cli.config_generation.BUILD_DIR", pathlib.Path(tmp_dir)
             ), patch(
+                "data_pipelines_cli.cli_commands.compile.BUILD_DIR",
+                pathlib.Path(tmp_dir),
+            ), patch(
                 "data_pipelines_cli.dbt_utils.BUILD_DIR", pathlib.Path(tmp_dir)
             ), patch(
                 "data_pipelines_cli.dbt_utils.subprocess_run", self._mock_run
@@ -55,6 +58,9 @@ class RunTestCommandTestCase(unittest.TestCase):
                     "pathlib.Path.cwd", lambda: self.goldens_dir_path
                 ), tempfile.TemporaryDirectory() as tmp_dir, patch(
                     "data_pipelines_cli.config_generation.BUILD_DIR",
+                    pathlib.Path(tmp_dir),
+                ), patch(
+                    "data_pipelines_cli.cli_commands.compile.BUILD_DIR",
                     pathlib.Path(tmp_dir),
                 ), patch(
                     "data_pipelines_cli.dbt_utils.BUILD_DIR", pathlib.Path(tmp_dir)


### PR DESCRIPTION
* Add `--version` flag
* Rename `gcp` to `gcs` in requirements
* Mention `fsspec`'s implementation kwargs in docs (and link to GCSFileSystem and S3FileSystem documentations)
* Set default env in `dp compile` to `base`
* Run `dp compile` at the beginning of `dp run` (instead of just the `dbt deps`)

---
Keep in mind:
- [X] Documentation updates
- [X] [Changelog](CHANGELOG.md) updates