### PR TITLE
Make global vars take precedence over project ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - `dp init` and `dp create` automatically adds `.git` suffix to given template paths, if necessary.
+- When reading dbt variables, global-scoped variables take precedence over project-scoped ones (it was another way around before).
 
 ## [0.7.0] - 2021-12-29
 

--- a/data_pipelines_cli/dbt_utils.py
+++ b/data_pipelines_cli/dbt_utils.py
@@ -33,7 +33,7 @@ def read_dbt_vars_from_configs(env: str) -> Dict[str, Any]:
     dp_vars = dp_config.get("vars", {})
     dbt_vars: Dict[str, str] = dbt_env_config.get("vars", {})
 
-    return dict(dp_vars, **dbt_vars)
+    return dict(dbt_vars, **dp_vars)
 
 
 def _dump_dbt_vars_from_configs_to_string(env: str) -> str:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -128,7 +128,7 @@ You can also add "global" variables to your **dp** config file ``$HOME/.dp.yml``
 get erased on every ``dp init`` call. It is a great idea to put *commonly used* variables in your organization's
 ``dp.yml.tmpl`` template and make **copier** ask for those when initializing **dp**. By doing so, each member of your
 organization will end up with a list of user-specific variables reusable across different projects on its machine.
-Just remember, **project-scoped variables take precedence over global-scoped ones.**
+Just remember, **global-scoped variables take precedence over project-scoped ones.**
 
 Project compilation
 -------------------

--- a/tests/test_dbt_utils.py
+++ b/tests/test_dbt_utils.py
@@ -21,6 +21,9 @@ class DbtUtilsTest(unittest.TestCase):
     dbt_config = {
         "target": "env_execution",
         "target_type": "bigquery",
+        "vars": {
+            "var1": 2,
+        },
     }
     goldens_dir_path = pathlib.Path(__file__).parent.joinpath("goldens")
 


### PR DESCRIPTION
---
Keep in mind:
- [X] Documentation updates
- [X] [Changelog](CHANGELOG.md) updates