### PR TITLE
Move repository and datahub uri options to config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Added
+
+- `--env` flag to `dp deploy`.
+
+### Changed
+
+- Docker repository URI gets read out of `build/config/{env}/k8s.yml`.
+
+### Removed
+
+- `--docker-repository-uri` and `--datahub-gms-uri` from `dp compile` and `dp deploy` commands.
+- `dp compile` no longer replaces `<INGEST_ENDPOINT>` in `datahub.yml`, or `<DOCKER_REPOSITORY_URL>` in `k8s.yml`
+
 ## [0.8.0] - 2021-12-31
 
 ### Changed

--- a/data_pipelines_cli/cli_commands/compile.py
+++ b/data_pipelines_cli/cli_commands/compile.py
@@ -1,17 +1,10 @@
 import pathlib
 import shutil
-from typing import Optional
 
 import click
 
-from ..cli_constants import (
-    BUILD_DIR,
-    DATAHUB_URL_ENV,
-    DOCKER_REPOSITORY_URL_TO_REPLACE,
-    IMAGE_TAG_TO_REPLACE,
-    INGEST_ENDPOINT_TO_REPLACE,
-)
-from ..cli_utils import echo_info, echo_warning, get_argument_or_environment_variable
+from ..cli_constants import BUILD_DIR, IMAGE_TAG_TO_REPLACE
+from ..cli_utils import echo_info
 from ..config_generation import (
     copy_config_dir_to_build_dir,
     copy_dag_dir_to_build_dir,
@@ -19,7 +12,7 @@ from ..config_generation import (
 )
 from ..data_structures import DockerArgs
 from ..dbt_utils import run_dbt_command
-from ..errors import DataPipelinesError, DockerNotInstalledError
+from ..errors import DockerNotInstalledError
 from ..io_utils import replace
 
 
@@ -28,16 +21,6 @@ def _replace_image_tag(k8s_config: pathlib.Path, docker_args: DockerArgs) -> Non
         f"Replacing {IMAGE_TAG_TO_REPLACE} with commit SHA = {docker_args.commit_sha}"
     )
     replace(k8s_config, IMAGE_TAG_TO_REPLACE, docker_args.commit_sha)
-
-
-def _replace_docker_repository_url(
-    k8s_config: pathlib.Path, docker_args: DockerArgs
-) -> None:
-    echo_info(
-        f"Replacing {DOCKER_REPOSITORY_URL_TO_REPLACE} with repository URL = "
-        f"{docker_args.repository}"
-    )
-    replace(k8s_config, DOCKER_REPOSITORY_URL_TO_REPLACE, docker_args.repository)
 
 
 def _docker_build(docker_args: DockerArgs) -> None:
@@ -82,37 +65,13 @@ def _copy_dbt_manifest() -> None:
     )
 
 
-def _try_replace_datahub_address(datahub_gms_uri: Optional[str]) -> None:
-    try:
-        datahub_gms_uri = get_argument_or_environment_variable(
-            datahub_gms_uri, "datahub-gms-uri", DATAHUB_URL_ENV
-        )
-    except DataPipelinesError as err:
-        echo_warning(
-            f"{err.message}\n{INGEST_ENDPOINT_TO_REPLACE} will not be replaced"
-        )
-        return
-
-    echo_info(
-        f"Replacing {INGEST_ENDPOINT_TO_REPLACE} with DataHub URI = {datahub_gms_uri}"
-    )
-    replace(
-        BUILD_DIR.joinpath("dag", "config", "base", "datahub.yml"),
-        INGEST_ENDPOINT_TO_REPLACE,
-        datahub_gms_uri,
-    )
-
-
 def _replace_k8s_settings(docker_args: DockerArgs) -> None:
     k8s_config: pathlib.Path = BUILD_DIR.joinpath("dag", "config", "base", "k8s.yml")
     _replace_image_tag(k8s_config, docker_args)
-    _replace_docker_repository_url(k8s_config, docker_args)
 
 
 def compile_project(
     env: str,
-    docker_repository_uri: Optional[str] = None,
-    datahub_gms_uri: Optional[str] = None,
     docker_build: bool = False,
 ) -> None:
     """
@@ -120,10 +79,6 @@ def compile_project(
 
     :param env: Name of the environment
     :type env: str
-    :param docker_repository_uri: URI of the Docker repository
-    :type docker_repository_uri: Optional[str]
-    :param datahub_gms_uri: URI of the DataHub ingestion endpoint
-    :type datahub_gms_uri: Optional[str]
     :param docker_build: Whether to build a Docker image
     :type docker_build: bool
     :raises DataPipelinesError:
@@ -131,16 +86,13 @@ def compile_project(
     copy_dag_dir_to_build_dir()
     copy_config_dir_to_build_dir()
 
-    docker_args = None
-    if docker_repository_uri:
-        docker_args = DockerArgs(docker_repository_uri)
-        _replace_k8s_settings(docker_args)
+    docker_args = DockerArgs(env)
+    _replace_k8s_settings(docker_args)
 
     _dbt_compile(env)
     _copy_dbt_manifest()
-    _try_replace_datahub_address(datahub_gms_uri)
 
-    if docker_build and docker_args:
+    if docker_build:
         _docker_build(docker_args)
 
 
@@ -157,12 +109,6 @@ def compile_project(
     help="Name of the environment",
 )
 @click.option(
-    "--docker-repository-uri", default=None, help="URI of the Docker repository"
-)
-@click.option(
-    "--datahub-gms-uri", default=None, help="URI of the DataHub ingestion endpoint"
-)
-@click.option(
     "--docker-build",
     is_flag=True,
     default=False,
@@ -170,8 +116,6 @@ def compile_project(
 )
 def compile_project_command(
     env: str,
-    docker_repository_uri: Optional[str],
-    datahub_gms_uri: Optional[str],
     docker_build: bool,
 ) -> None:
-    compile_project(env, docker_repository_uri, datahub_gms_uri, docker_build)
+    compile_project(env, docker_build)

--- a/data_pipelines_cli/cli_commands/deploy.py
+++ b/data_pipelines_cli/cli_commands/deploy.py
@@ -34,12 +34,13 @@ class DeployCommand:
 
     def __init__(
         self,
-        docker_push: Optional[str],
+        env: str,
+        docker_push: bool,
         dags_path: Optional[str],
         provider_kwargs_dict: Optional[Dict[str, Any]],
         datahub_ingest: bool,
     ) -> None:
-        self.docker_args = DockerArgs(docker_push) if docker_push else None
+        self.docker_args = DockerArgs(env) if docker_push else None
         self.datahub_ingest = datahub_ingest
         self.provider_kwargs_dict = provider_kwargs_dict or {}
 
@@ -124,6 +125,7 @@ class DeployCommand:
     name="deploy",
     help="Push and deploy the project to the remote machine",
 )
+@click.option("--env", default="base", type=str, help="Name of the environment")
 @click.option("--dags-path", required=False, help="Remote storage URI")
 @click.option(
     "--blob-args",
@@ -132,7 +134,13 @@ class DeployCommand:
     help="Path to JSON or YAML file with arguments that should be passed to "
     "your Bucket/blob provider",
 )
-@click.option("--docker-push", default=None, help="Path to the Docker repository")
+@click.option(
+    "--docker-push",
+    type=bool,
+    is_flag=True,
+    default=False,
+    help="Whether to push image to the Docker repository",
+)
 @click.option(
     "--datahub-ingest",
     is_flag=True,
@@ -140,9 +148,10 @@ class DeployCommand:
     help="Whether to ingest DataHub metadata",
 )
 def deploy_command(
+    env: str,
     dags_path: Optional[str],
     blob_args: Optional[io.TextIOWrapper],
-    docker_push: Optional[str],
+    docker_push: bool,
     datahub_ingest: bool,
 ) -> None:
     if blob_args:
@@ -155,6 +164,7 @@ def deploy_command(
         provider_kwargs_dict = None
 
     DeployCommand(
+        env,
         docker_push,
         dags_path,
         provider_kwargs_dict,

--- a/data_pipelines_cli/cli_constants.py
+++ b/data_pipelines_cli/cli_constants.py
@@ -2,14 +2,8 @@ import pathlib
 
 from data_pipelines_cli.data_structures import DataPipelinesConfig
 
-#: DataHub URL environment variable to search for
-DATAHUB_URL_ENV: str = "DATAHUB_URL"
 #:
 IMAGE_TAG_TO_REPLACE: str = "<IMAGE_TAG>"
-#:
-DOCKER_REPOSITORY_URL_TO_REPLACE: str = "<DOCKER_REPOSITORY_URL>"
-#:
-INGEST_ENDPOINT_TO_REPLACE: str = "<INGEST_ENDPOINT>"
 #: Name of the environment and dbt target to use for a local machine
 PROFILE_NAME_LOCAL_ENVIRONMENT = "local"
 #: Name of the dbt target to use for a remote machine

--- a/tests/cli_commands/test_run_test.py
+++ b/tests/cli_commands/test_run_test.py
@@ -35,6 +35,8 @@ class RunTestCommandTestCase(unittest.TestCase):
             ), patch(
                 "data_pipelines_cli.dbt_utils.BUILD_DIR", pathlib.Path(tmp_dir)
             ), patch(
+                "data_pipelines_cli.cli_constants.BUILD_DIR", pathlib.Path(tmp_dir)
+            ), patch(
                 "data_pipelines_cli.dbt_utils.subprocess_run", self._mock_run
             ):
                 runner = CliRunner()
@@ -64,6 +66,8 @@ class RunTestCommandTestCase(unittest.TestCase):
                     pathlib.Path(tmp_dir),
                 ), patch(
                     "data_pipelines_cli.dbt_utils.BUILD_DIR", pathlib.Path(tmp_dir)
+                ), patch(
+                    "data_pipelines_cli.cli_constants.BUILD_DIR", pathlib.Path(tmp_dir)
                 ), patch(
                     "data_pipelines_cli.dbt_utils.subprocess_run", self._mock_run
                 ):

--- a/tests/goldens/config/base/datahub.yml
+++ b/tests/goldens/config/base/datahub.yml
@@ -1,3 +1,3 @@
 sink:
   config:
-    server: "https://<INGEST_ENDPOINT>:8080"
+    server: "https://ingest.some-datahub-endpoint.co.uk:8080"

--- a/tests/goldens/config/base/k8s.yml
+++ b/tests/goldens/config/base/k8s.yml
@@ -1,5 +1,5 @@
 image:
-  repository: <DOCKER_REPOSITORY_URL>
+  repository: my_docker_repository_uri
   tag: <IMAGE_TAG>
 variable1: 1337
 var2: "Hello, world!"

--- a/tests/test_data_structures.py
+++ b/tests/test_data_structures.py
@@ -1,5 +1,5 @@
-import os
 import pathlib
+import shutil
 import tempfile
 import unittest
 from unittest.mock import patch
@@ -52,30 +52,45 @@ class DataStructuresTestCase(unittest.TestCase):
 
 
 class DockerArgsTest(unittest.TestCase):
+    goldens_dir_path = pathlib.Path(__file__).parent.joinpath("goldens")
+
+    def setUp(self) -> None:
+        self.build_temp_dir = pathlib.Path(tempfile.mkdtemp())
+        dags_path = pathlib.Path(self.build_temp_dir).joinpath("dag")
+        dags_path.mkdir(parents=True)
+        shutil.copytree(
+            self.goldens_dir_path.joinpath("config"), dags_path.joinpath("config")
+        )
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.build_temp_dir)
+
     @patch("data_pipelines_cli.data_structures.git_revision_hash")
     def test_build_tag(self, mock_git_revision_hash):
-        repository = "rep"
+        repository = "my_docker_repository_uri"
         commit_sha = "eee440bfbe0801ec3f533f897c1d55e6a5afd5cd"
         mock_git_revision_hash.return_value = commit_sha
 
-        docker_args = DockerArgs(repository)
+        with patch("data_pipelines_cli.cli_constants.BUILD_DIR", self.build_temp_dir):
+            docker_args = DockerArgs("base")
+
         self.assertEqual(f"{repository}:{commit_sha}", docker_args.docker_build_tag())
         self.assertEqual(repository, docker_args.repository)
         self.assertEqual(commit_sha, docker_args.commit_sha)
+
+    @patch("data_pipelines_cli.cli_constants.BUILD_DIR", goldens_dir_path)
+    @patch("data_pipelines_cli.data_structures.git_revision_hash")
+    def test_no_repository(self, mock_git_revision_hash):
+        commit_sha = "eee440bfbe0801ec3f533f897c1d55e6a5afd5cd"
+        mock_git_revision_hash.return_value = commit_sha
+
+        with self.assertRaises(DataPipelinesError):
+            _ = DockerArgs("base")
 
     @patch("data_pipelines_cli.data_structures.git_revision_hash")
     def test_no_git_hash(self, mock_git_revision_hash):
         mock_git_revision_hash.return_value = None
 
-        with self.assertRaises(DataPipelinesError):
-            _ = DockerArgs("rep")
-
-    @patch("data_pipelines_cli.data_structures.git_revision_hash")
-    @patch.dict(os.environ, {"REPOSITORY_URL": "repo"})
-    def test_no_repository_argument(self, mock_git_revision_hash):
-        commit_sha = "eee440bfbe0801ec3f533f897c1d55e6a5afd5cd"
-        mock_git_revision_hash.return_value = commit_sha
-
-        docker_args = DockerArgs(None)
-        self.assertEqual("repo", docker_args.repository)
-        self.assertEqual(commit_sha, docker_args.commit_sha)
+        with patch("data_pipelines_cli.cli_constants.BUILD_DIR", self.build_temp_dir):
+            with self.assertRaises(DataPipelinesError):
+                _ = DockerArgs("base")


### PR DESCRIPTION
This PR removes `--docker-repository-uri` and `--datahub-gms-uri` from `dp compile` and `dp deploy` commands. It is because `dp compile` no longer replaces `<INGEST_ENDPOINT>` in `datahub.yml`, or `<DOCKER_REPOSITORY_URL>` in `k8s.yml`. Instead, users shall put those into their config files before running `dp compile`.

---
Keep in mind:
- [ ] Documentation updates
- [X] [Changelog](CHANGELOG.md) updates