### PR TITLE
BI deployment is disabled when config is missing

### DIFF
--- a/data_pipelines_cli/bi_utils.py
+++ b/data_pipelines_cli/bi_utils.py
@@ -56,7 +56,7 @@ def bi(env: str, bi_action: BiAction, key_path: Optional[str] = None) -> None:
     """
     bi_config = read_bi_config(env)
 
-    if not bi_config["is_bi_enabled"]:
+    if not bi_config.get("is_bi_enabled", False):
         echo_info("BI is disabled")
         return
 

--- a/tests/test_bi_utils.py
+++ b/tests/test_bi_utils.py
@@ -54,6 +54,13 @@ class BiUtilsTestCase(unittest.TestCase):
             bi("env", BiAction.COMPILE)
             _bi_looker_mock.assert_not_called()
 
+    @patch("data_pipelines_cli.bi_utils._bi_looker")
+    @patch("data_pipelines_cli.bi_utils.read_bi_config")
+    def test_bi_disabled_when_config_not_exists(self, mock_read_bi_config, mock__bi_looker):
+        mock_read_bi_config.return_value = {}
+        bi("non_existent_env", BiAction.COMPILE)
+        mock__bi_looker.assert_not_called()
+
     def test_bi_not_supported_bi(self):
         bi_config = {
             "is_bi_enabled": True,


### PR DESCRIPTION
BI deployment is disabled when config is missing

Resolves [DATA-557](https://getindata.atlassian.net/browse/DATA-557)

---
Keep in mind:
- [ ] Documentation updates
- [ ] [Changelog](CHANGELOG.md) updates