### PR TITLE
feat: disable sync bucket

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,21 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally declare the Python requirements required to build your docs
+python:
+  install:
+  - requirements: docs/requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+### Added
+- Ability to turn off `sync_bucket` due to limitations of the fsspec package [#101](https://github.com/getindata/data-pipelines-cli/issues/101)
 ## [0.24.2] - 2023-04-14
 
 -   Added Airbyte integration documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Ability to turn off `sync_bucket` due to limitations of the fsspec package [#101](https://github.com/getindata/data-pipelines-cli/issues/101) using `--disable-bucket-sync` flag
+- Ability to apply `disable_bucket_sync` due to limitations of the fsspec package [#101](https://github.com/getindata/data-pipelines-cli/issues/101) using `--disable-bucket-sync` flag
 
 ## [0.24.2] - 2023-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## [Unreleased]
 
 ### Added
+
 - Ability to turn off `sync_bucket` due to limitations of the fsspec package [#101](https://github.com/getindata/data-pipelines-cli/issues/101)
+
 ## [0.24.2] - 2023-04-14
 
 -   Added Airbyte integration documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Ability to turn off `sync_bucket` due to limitations of the fsspec package [#101](https://github.com/getindata/data-pipelines-cli/issues/101)
+- Ability to turn off `sync_bucket` due to limitations of the fsspec package [#101](https://github.com/getindata/data-pipelines-cli/issues/101) using `--disable-bucket-sync` flag
 
 ## [0.24.2] - 2023-04-14
 

--- a/data_pipelines_cli/cli_commands/deploy.py
+++ b/data_pipelines_cli/cli_commands/deploy.py
@@ -202,10 +202,10 @@ class DeployCommand:
     help="Authorization OIDC ID token for a service account to communication with cloud services",
 )
 @click.option(
-    "--sync-bucket",
+    "--disable-bucket-sync",
     is_flag=True,
-    default=False,
-    help="Whether to sync bucket with artefacts",
+    default=True,
+    help="Whether to disable bucket sync with artefacts",
 )
 def deploy_command(
     env: str,
@@ -215,7 +215,7 @@ def deploy_command(
     datahub_ingest: bool,
     bi_git_key_path: str,
     auth_token: Optional[str],
-    sync_bucket: bool,
+    disable_bucket_sync: bool,
 ) -> None:
     if blob_args:
         try:
@@ -234,5 +234,5 @@ def deploy_command(
         datahub_ingest,
         bi_git_key_path,
         auth_token,
-        sync_bucket,
+        disable_bucket_sync,
     ).deploy()

--- a/data_pipelines_cli/cli_commands/deploy.py
+++ b/data_pipelines_cli/cli_commands/deploy.py
@@ -204,7 +204,7 @@ class DeployCommand:
 @click.option(
     "--sync-bucket",
     is_flag=True,
-    default=True,
+    default=False,
     help="Whether to sync bucket with artefacts",
 )
 def deploy_command(

--- a/data_pipelines_cli/cli_commands/deploy.py
+++ b/data_pipelines_cli/cli_commands/deploy.py
@@ -40,6 +40,8 @@ class DeployCommand:
     bi_git_key_path: str
     auth_token: Optional[str]
     """Authorization OIDC ID token for a service account to communication with Airbyte instance"""
+    sync_bucket: bool
+    """Whether to sync bucket with artefacts"""
 
     def __init__(
         self,
@@ -50,6 +52,7 @@ class DeployCommand:
         datahub_ingest: bool,
         bi_git_key_path: str,
         auth_token: Optional[str],
+        sync_bucket: bool,
     ) -> None:
         self.docker_args = DockerArgs(env, None, {}) if docker_push else None
         self.datahub_ingest = datahub_ingest
@@ -57,6 +60,7 @@ class DeployCommand:
         self.env = env
         self.bi_git_key_path = bi_git_key_path
         self.auth_token = auth_token
+        self.sync_bucket = sync_bucket
 
         try:
             self.blob_address_path = (
@@ -91,7 +95,8 @@ class DeployCommand:
 
         self._bi_push()
 
-        self._sync_bucket()
+        if self.sync_bucket:
+            self._sync_bucket()
 
     def _bi_push(self) -> None:
         bi(self.env, BiAction.DEPLOY, self.bi_git_key_path)
@@ -196,6 +201,12 @@ class DeployCommand:
     required=False,
     help="Authorization OIDC ID token for a service account to communication with cloud services",
 )
+@click.option(
+    "--sync-bucket",
+    is_flag=True,
+    default=True,
+    help="Whether to sync bucket with artefacts",
+)
 def deploy_command(
     env: str,
     dags_path: Optional[str],
@@ -204,6 +215,7 @@ def deploy_command(
     datahub_ingest: bool,
     bi_git_key_path: str,
     auth_token: Optional[str],
+    sync_bucket: bool,
 ) -> None:
     if blob_args:
         try:
@@ -222,4 +234,5 @@ def deploy_command(
         datahub_ingest,
         bi_git_key_path,
         auth_token,
+        sync_bucket,
     ).deploy()

--- a/data_pipelines_cli/cli_commands/deploy.py
+++ b/data_pipelines_cli/cli_commands/deploy.py
@@ -96,7 +96,7 @@ class DeployCommand:
         self._bi_push()
 
         if not self.disable_bucket_sync:
-            self._disable_bucket_sync()
+            self._bucket_sync()
 
     def _bi_push(self) -> None:
         bi(self.env, BiAction.DEPLOY, self.bi_git_key_path)
@@ -156,7 +156,7 @@ class DeployCommand:
             airbyte_config_path=airbyte_config_path, auth_token=self.auth_token
         ).create_update_connections()
 
-    def _disable_bucket_sync(self) -> None:
+    def _bucket_sync(self) -> None:
         echo_info("Syncing Bucket")
         LocalRemoteSync(
             BUILD_DIR.joinpath("dag"), self.blob_address_path, self.provider_kwargs_dict

--- a/tests/cli_commands/test_deploy.py
+++ b/tests/cli_commands/test_deploy.py
@@ -89,7 +89,7 @@ class DeployCommandTestCase(unittest.TestCase):
                     _datahub_ingest,
                     _bi_git_key_path,
                     _auth_token,
-                    _sync_bucket,
+                    _disable_bucket_sync,
                 ):
                     nonlocal result_provider_kwargs
                     result_provider_kwargs = provider_kwargs_dict
@@ -106,7 +106,7 @@ class DeployCommandTestCase(unittest.TestCase):
                 self.assertDictEqual(self.provider_args, result_provider_kwargs)
 
     @patch("data_pipelines_cli.cli_commands.deploy.BUILD_DIR", goldens_dir_path)
-    def test_sync_bucket_enabled(self):
+    def test_disable_bucket_sync_disabled(self):
         # Worth noting: we are not extensively testing
         # 'filesystem_utils.LocalRemoteSync' here. It gets tested in
         # a dedicated 'test_filesystem_utils' file.
@@ -131,7 +131,7 @@ class DeployCommandTestCase(unittest.TestCase):
         )
 
     @patch("data_pipelines_cli.cli_commands.deploy.BUILD_DIR", goldens_dir_path)
-    def test_sync_bucket_disabled(self):
+    def test_disable_bucket_sync_enabled(self):
         runner = CliRunner()
         with patch("pathlib.Path.cwd", lambda: self.dbt_project_config_dir), patch(
             "data_pipelines_cli.cli_commands.deploy.bi"

--- a/tests/cli_commands/test_deploy.py
+++ b/tests/cli_commands/test_deploy.py
@@ -106,7 +106,7 @@ class DeployCommandTestCase(unittest.TestCase):
                 self.assertDictEqual(self.provider_args, result_provider_kwargs)
 
     @patch("data_pipelines_cli.cli_commands.deploy.BUILD_DIR", goldens_dir_path)
-    def test_sync_bucket(self):
+    def test_sync_bucket_enabled(self):
         # Worth noting: we are not extensively testing
         # 'filesystem_utils.LocalRemoteSync' here. It gets tested in
         # a dedicated 'test_filesystem_utils' file.
@@ -128,6 +128,28 @@ class DeployCommandTestCase(unittest.TestCase):
         self.assertEqual(0, result.exit_code, msg=result.exception)
         self.assertEqual(
             2,
+            len(os.listdir(self.storage_uri)),
+        )
+
+    @patch("data_pipelines_cli.cli_commands.deploy.BUILD_DIR", goldens_dir_path)
+    def test_sync_bucket_disabled(self):
+        runner = CliRunner()
+        with patch("pathlib.Path.cwd", lambda: self.dbt_project_config_dir), patch(
+            "data_pipelines_cli.cli_commands.deploy.bi"
+        ):
+            result = runner.invoke(
+                _cli,
+                [
+                    "deploy",
+                    "--dags-path",
+                    self.storage_uri,
+                    "--blob-args",
+                    self.blob_json_filename,
+                ],
+            )
+        self.assertEqual(0, result.exit_code, msg=result.exception)
+        self.assertEqual(
+            0,
             len(os.listdir(self.storage_uri)),
         )
 

--- a/tests/cli_commands/test_deploy.py
+++ b/tests/cli_commands/test_deploy.py
@@ -89,6 +89,7 @@ class DeployCommandTestCase(unittest.TestCase):
                     _datahub_ingest,
                     _bi_git_key_path,
                     _auth_token,
+                    _sync_bucket,
                 ):
                     nonlocal result_provider_kwargs
                     result_provider_kwargs = provider_kwargs_dict
@@ -121,6 +122,7 @@ class DeployCommandTestCase(unittest.TestCase):
                     self.storage_uri,
                     "--blob-args",
                     self.blob_json_filename,
+                    "--sync-bucket",
                 ],
             )
         self.assertEqual(0, result.exit_code, msg=result.exception)
@@ -159,7 +161,7 @@ class DeployCommandTestCase(unittest.TestCase):
         ):
             with self.assertRaises(DependencyNotInstalledError):
                 DeployCommand(
-                    "base", False, self.storage_uri, self.provider_args, True, None, None
+                    "base", False, self.storage_uri, self.provider_args, True, None, None, True
                 ).deploy()
 
     @patch("data_pipelines_cli.cli_commands.deploy.BUILD_DIR", goldens_dir_path)
@@ -171,7 +173,7 @@ class DeployCommandTestCase(unittest.TestCase):
             "data_pipelines_cli.cli_commands.deploy.bi"
         ):
             DeployCommand(
-                "base", False, self.storage_uri, self.provider_args, True, None, None
+                "base", False, self.storage_uri, self.provider_args, True, None, None, True
             ).deploy()
             self.assertListEqual(
                 [
@@ -189,7 +191,7 @@ class DeployCommandTestCase(unittest.TestCase):
         ), patch("data_pipelines_cli.cli_constants.BUILD_DIR", self.build_temp_dir):
             with self.assertRaises(DependencyNotInstalledError):
                 DeployCommand(
-                    "base", True, self.storage_uri, self.provider_args, False, None, None
+                    "base", True, self.storage_uri, self.provider_args, False, None, None, True
                 ).deploy()
 
     @patch(
@@ -198,7 +200,7 @@ class DeployCommandTestCase(unittest.TestCase):
     )
     def test_no_airflow_address(self):
         with self.assertRaises(AirflowDagsPathKeyError):
-            DeployCommand("base", False, None, None, False, None, None)
+            DeployCommand("base", False, None, None, False, None, None, True)
 
     def test_airflow_address(self):
         with tempfile.TemporaryDirectory() as tmp_dir, patch(
@@ -213,7 +215,7 @@ class DeployCommandTestCase(unittest.TestCase):
                 tmp_airflow_path,
             )
 
-            deploy_command = DeployCommand("base", False, None, None, False, None, None)
+            deploy_command = DeployCommand("base", False, None, None, False, None, None, True)
         self.assertEqual(
             "gcs://test-sync-project/sync-dir/dags/my-project-name",
             deploy_command.blob_address_path,
@@ -235,7 +237,7 @@ class DeployCommandTestCase(unittest.TestCase):
                     tmp_file_path,
                 )
 
-            deploy_command = DeployCommand("staging", False, None, None, False, None, None)
+            deploy_command = DeployCommand("staging", False, None, None, False, None, None, True)
         self.assertEqual(
             "gcs://test/jinja/path/com/my/project/name",
             deploy_command.blob_address_path,
@@ -267,7 +269,7 @@ class DeployCommandTestCase(unittest.TestCase):
             "data_pipelines_cli.cli_commands.deploy.bi"
         ):
             DeployCommand(
-                "base", True, self.storage_uri, self.provider_args, False, None, None
+                "base", True, self.storage_uri, self.provider_args, False, None, None, True
             ).deploy()
 
         self.assertEqual("my_docker_repository_uri", docker_kwargs.get("repository"))
@@ -297,7 +299,7 @@ class DeployCommandTestCase(unittest.TestCase):
         ):
             with self.assertRaises(DataPipelinesError):
                 DeployCommand(
-                    "base", True, self.storage_uri, self.provider_args, False, None, None
+                    "base", True, self.storage_uri, self.provider_args, False, None, None, True
                 ).deploy()
 
     def test_ingestion_is_false_by_default(self):
@@ -305,7 +307,7 @@ class DeployCommandTestCase(unittest.TestCase):
             "data_pipelines_cli.cli_commands.deploy.BUILD_DIR", self.build_temp_dir
         ):
             deploy_command = DeployCommand(
-                "prod", True, self.storage_uri, self.provider_args, False, None, None
+                "prod", True, self.storage_uri, self.provider_args, False, None, None, True
             )
             self.assertEqual(deploy_command.enable_ingest, False)
 
@@ -314,6 +316,6 @@ class DeployCommandTestCase(unittest.TestCase):
             "data_pipelines_cli.cli_commands.deploy.BUILD_DIR", self.build_temp_dir
         ):
             deploy_command = DeployCommand(
-                "dev", True, self.storage_uri, self.provider_args, False, None, None
+                "dev", True, self.storage_uri, self.provider_args, False, None, None, True
             )
             self.assertEqual(deploy_command.enable_ingest, True)

--- a/tests/cli_commands/test_deploy.py
+++ b/tests/cli_commands/test_deploy.py
@@ -122,7 +122,6 @@ class DeployCommandTestCase(unittest.TestCase):
                     self.storage_uri,
                     "--blob-args",
                     self.blob_json_filename,
-                    "--sync-bucket",
                 ],
             )
         self.assertEqual(0, result.exit_code, msg=result.exception)
@@ -145,6 +144,7 @@ class DeployCommandTestCase(unittest.TestCase):
                     self.storage_uri,
                     "--blob-args",
                     self.blob_json_filename,
+                    "--disable-bucket-sync",
                 ],
             )
         self.assertEqual(0, result.exit_code, msg=result.exception)


### PR DESCRIPTION
Resolves #101 

changes:
- A new config file, .readthedocs.yaml, has been added for reference due to the release of [urllib3](https://github.com/readthedocs/readthedocs.org/issues/10290)
- The CLI now allows users to turn off the sync bucket feature using `--disable-bucket-sync` flag

---
Keep in mind:
- [X] Documentation updates
- [X] [Changelog](CHANGELOG.md) updates