### PR TITLE
Fix failing readthedocs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.10"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -18,4 +18,7 @@ sphinx:
 # Optionally declare the Python requirements required to build your docs
 python:
   install:
-  - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+-   Failing readthedocs documentations build resulting in empty pages`
+
 ## [0.25.0] - 2023-05-15
 
 ### Added

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,0 @@
-sphinx-rtd-theme==1.0.0
-sphinx-click>=4.0,<4.1
-myst-parser>=0.17, <0.18
-docutils>=0.17,<0.18
-GitPython==3.1.26
-colorama==0.4.4
-MarkupSafe<2.1
-Werkzeug==2.0.3

--- a/docs/setup_environment.rst
+++ b/docs/setup_environment.rst
@@ -29,8 +29,8 @@ The repository should contain ``dp.yml.tmpl`` file looking similar to this:
 
 .. code-block:: yaml
 
-_templates_suffix: ".tmpl"
-_envops:
+  _templates_suffix: ".tmpl"
+  _envops:
     autoescape: false
     block_end_string: "%]"
     block_start_string: "[%"

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ EXTRA_REQUIRE = {
         "myst-parser==0.18.1",
         "GitPython==3.1.29",
         "colorama==0.4.5",
-        "pytz==2023.3"
+        "pytz==2023.3",
     ],
     **EXTRA_FILESYSTEMS_REQUIRE,
 }

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ EXTRA_REQUIRE = {
         "myst-parser==0.18.1",
         "GitPython==3.1.29",
         "colorama==0.4.5",
+        "pytz==2023.3"
     ],
     **EXTRA_FILESYSTEMS_REQUIRE,
 }


### PR DESCRIPTION
Fix failing readthedocs builds i.e.: https://readthedocs.org/projects/data-pipelines-cli/builds/20704328/ Traceback available below.

Now readthedocs should be configured with:
- Python 3.10 (highest available that is not failing builds)
- install command: `pip install .[docs]`
- included `pytz` in the dependecy list

---
Keep in mind:
- [ ] Documentation updates
- [ ] [Changelog](CHANGELOG.md) updates