### PR TITLE
Sort out documentation building in pipelines

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -36,11 +36,6 @@ jobs:
         uses: thomaseizinger/keep-a-changelog-new-release@v1
         with:
           version: ${{ steps.bump_version.outputs.package_version }}
-      - name: Ensure source docs are updated
-        uses: ammaraskar/sphinx-action@master
-        with:
-          docs-folder: "docs/"
-          build-command: "make apidoc html"
       - name: Create a new release branch
         run: |
           git config user.name github-actions


### PR DESCRIPTION
# Description

ATM we have two methods of building the package documentation with sphinx:
- github action https://github.com/ammaraskar/sphinx-action during prepare-release
- readthedocs itself https://readthedocs.org/projects/data-pipelines-cli/builds

The sphinx-action is outdated and depends on `docs/requirements.txt` that we want to avoid using in order not to maintain separate list of dependencies. Readthedocs on the other side is already able to install dependencies via `pip install .[docs]` command. 

# Proposed actions:

1. remove ammaraskar/sphinx-action 
2. connect pipelines to readthedocs builds that are already happening

---
Keep in mind:
- [ ] Documentation updates
- [ ] [Changelog](CHANGELOG.md) updates