### PR TITLE
Airbyte fix creating multiple connections

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
     env:
       PYTHON_PACKAGE: data_pipelines_cli
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- AirbyteFactory creating duplicated connections
+
 ## [0.25.1] - 2023-05-16
 
 ### Fixed

--- a/data_pipelines_cli/airbyte_utils.py
+++ b/data_pipelines_cli/airbyte_utils.py
@@ -106,7 +106,7 @@ class AirbyteFactory:
         echo_info(f"Updating connection config for {connection_config_copy['name']}")
         connection_config_copy.pop("sourceId", None)
         connection_config_copy.pop("destinationId", None)
-        connection_config_copy["connectionId"] = response_search["connections"][0]["connectionId"]
+        connection_config_copy["connectionId"] = matching_connections[0]["connectionId"]
         response_update = self.request_handler(
             "connections/update",
             connection_config_copy,

--- a/data_pipelines_cli/airbyte_utils.py
+++ b/data_pipelines_cli/airbyte_utils.py
@@ -50,7 +50,8 @@ class AirbyteFactory:
         if not self.airbyte_config["connections"]:
             return
 
-        if not (workspace_id := self.airbyte_config.get("workspace_id")):
+        workspace_id = self.airbyte_config.get("workspace_id")
+        if not workspace_id:
             raise AirbyteConfigMissingWorkspaceIdError(
                 "Property workspace_id not found in Airbyte config."
             )

--- a/data_pipelines_cli/airbyte_utils.py
+++ b/data_pipelines_cli/airbyte_utils.py
@@ -127,7 +127,6 @@ class AirbyteFactory:
 
         try:
             response = requests.post(url=url, headers=headers, json=data)
-            echo_info(str(response.status_code))
             response.raise_for_status()
             data = response.json()
             return data

--- a/data_pipelines_cli/airbyte_utils.py
+++ b/data_pipelines_cli/airbyte_utils.py
@@ -1,15 +1,22 @@
 import ast
 import copy
-import json
 import os
 import pathlib
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Iterable, Optional, Union
 
 import requests
 import yaml
 
 from .cli_constants import BUILD_DIR
 from .cli_utils import echo_error, echo_info
+
+
+class AirbyteError(Exception):
+    pass
+
+
+class AirbyteNoWorkspaceConfiguredError(AirbyteError):
+    pass
 
 
 class AirbyteFactory:
@@ -48,42 +55,68 @@ class AirbyteFactory:
             [task.update(self.env_replacer(task)) for task in self.airbyte_config["tasks"]]
             self.update_file(self.airbyte_config)
 
+    def get_workspace_id(self) -> str:
+        workspaces = self.request_handler("workspaces/list").get("workspaces")
+        if not workspaces:
+            raise AirbyteNoWorkspaceConfiguredError(
+                f"No workspaces found in {self.airbyte_url} instance."
+            )
+
+        return workspaces[0].get("workspaceId")
+
     def create_update_connection(self, connection_config: Dict[str, Any]) -> Any:
+        def configs_equal(
+            conf_a: Dict[str, Any], conf_b: Dict[str, Any], equality_fields: Iterable[str]
+        ) -> bool:
+            conn_a = {k: v for k, v in conf_a.items() if k in equality_fields}
+            conn_b = {k: v for k, v in conf_b.items() if k in equality_fields}
+            return conn_a == conn_b
+
         connection_config_copy = copy.deepcopy(connection_config)
         response_search = self.request_handler(
-            "connections/search",
-            {
-                "sourceId": connection_config_copy["sourceId"],
-                "destinationId": connection_config_copy["destinationId"],
-                "namespaceDefinition": connection_config_copy["namespaceDefinition"],
-                "namespaceFormat": connection_config_copy["namespaceFormat"],
-            },
+            "connections/list",
+            data={"workspaceId": self.get_workspace_id()},
         )
-        if not response_search["connections"]:
+
+        equality_fields = [
+            "sourceId",
+            "destinationId",
+            "namespaceDefinition",
+            "namespaceFormat",
+        ]
+
+        matching_connections = [
+            connection
+            for connection in response_search["connections"]
+            if configs_equal(connection_config_copy, connection, equality_fields)
+        ]
+
+        if not matching_connections:
             echo_info(f"Creating connection config for {connection_config_copy['name']}")
             response_create = self.request_handler(
                 "connections/create",
                 connection_config_copy,
             )
             os.environ[response_create["name"]] = response_create["connectionId"]
-        else:
-            echo_info(f"Updating connection config for {connection_config_copy['name']}")
-            connection_config_copy.pop("sourceId", None)
-            connection_config_copy.pop("destinationId", None)
-            connection_config_copy["connectionId"] = response_search["connections"][0][
-                "connectionId"
-            ]
-            response_update = self.request_handler(
-                "connections/update",
-                connection_config_copy,
-            )
-            os.environ[response_update["name"]] = response_update["connectionId"]
+            return
+
+        echo_info(f"Updating connection config for {connection_config_copy['name']}")
+        connection_config_copy.pop("sourceId", None)
+        connection_config_copy.pop("destinationId", None)
+        connection_config_copy["connectionId"] = response_search["connections"][0]["connectionId"]
+        response_update = self.request_handler(
+            "connections/update",
+            connection_config_copy,
+        )
+        os.environ[response_update["name"]] = response_update["connectionId"]
 
     def update_file(self, updated_config: Dict[str, Any]) -> None:
         with open(self.airbyte_config_path, "w") as airbyte_config_file:
             yaml.safe_dump(updated_config, airbyte_config_file)
 
-    def request_handler(self, endpoint: str, config: Dict[str, Any]) -> Union[Dict[str, Any], Any]:
+    def request_handler(
+        self, endpoint: str, data: Optional[Dict[str, Any]] = None
+    ) -> Union[Dict[str, Any], Any]:
         url = f"{self.airbyte_url}/api/v1/{endpoint}"
         headers = {
             "Accept": "application/json",
@@ -93,7 +126,8 @@ class AirbyteFactory:
             headers["Authorization"] = f"Bearer {self.auth_token}"
 
         try:
-            response = requests.post(url=url, headers=headers, data=json.dumps(config))
+            response = requests.post(url=url, headers=headers, json=data)
+            echo_info(str(response.status_code))
             response.raise_for_status()
             data = response.json()
             return data

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -225,6 +225,9 @@ Ingestion configuration is divided into two levels:
    * - airbyte_url
      - string
      - Https address of Airbyte deployment that allows to connect to Airbyte API
+   * - workspace_id
+     - uuid
+     - Id of the workspace that contains connections defined in the config
    * - connections
      - array<*connection*>
      - Configurations of Airbyte connections that should be upserted during CI/CD. Minimal connection schema is documented below.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -227,7 +227,7 @@ Ingestion configuration is divided into two levels:
      - Https address of Airbyte deployment that allows to connect to Airbyte API
    * - workspace_id
      - uuid
-     - Id of the workspace that contains connections defined in the config
+     - Optional ID of the workspace that contains connections defined in the config. If not provided, it will be automatically fetched from Airbyte API.
    * - connections
      - array<*connection*>
      - Configurations of Airbyte connections that should be upserted during CI/CD. Minimal connection schema is documented below.

--- a/tests/goldens/config/airbyte/airbyte.yml
+++ b/tests/goldens/config/airbyte/airbyte.yml
@@ -1,5 +1,6 @@
 airbyte_connection_id: airbyte_connection_id
 airbyte_url: https://airbyte.dataops-dev.getindata.dev
+workspace_id: 35ac8060-b4da-4742-b5ba-16ce29dcf526
 connections:
   POSTGRES_BQ_CONNECTION:
     destinationId: b3696ac3-93b2-4039-9021-e1f884b03a95

--- a/tests/test_airbyte_utils.py
+++ b/tests/test_airbyte_utils.py
@@ -8,7 +8,10 @@ from unittest.mock import Mock, call, patch
 import yaml
 from requests import HTTPError
 
-from data_pipelines_cli.airbyte_utils import AirbyteFactory
+from data_pipelines_cli.airbyte_utils import (
+    AirbyteConfigMissingWorkspaceIdError,
+    AirbyteFactory,
+)
 
 
 def read_file(file_path: pathlib.Path):
@@ -205,3 +208,9 @@ class AirbyteUtilsTest(unittest.TestCase):
         self.assertEqual(
             os.environ["POSTGRES_BQ_CONNECTION"], "7aa68945-3e4b-4e1c-b504-2c36e5be2952"
         )
+
+    def test_missing_worskpace_id_error_is_raised(self):
+        self.test_airbyte_factory.airbyte_config.pop("workspace_id")
+
+        with self.assertRaises(AirbyteConfigMissingWorkspaceIdError):
+            self.test_airbyte_factory.create_update_connections()

--- a/tests/test_airbyte_utils.py
+++ b/tests/test_airbyte_utils.py
@@ -153,6 +153,7 @@ class AirbyteUtilsTest(unittest.TestCase):
     @patch("data_pipelines_cli.airbyte_utils.AirbyteFactory.request_handler")
     def test_create_connection(self, mock_request_handler):
         mock_request_handler.side_effect = [
+            {"workspaces": [{"workspaceId": "6e832a27-a146-46b6-9d0b-ca2fad5e476f"}]},
             {"connections": []},
             {
                 "name": "POSTGRES_BQ_CONNECTION",
@@ -163,6 +164,10 @@ class AirbyteUtilsTest(unittest.TestCase):
         self.test_airbyte_factory.create_update_connection(
             self.airbyte_config["connections"]["POSTGRES_BQ_CONNECTION"]
         )
+
+        endpoint = mock_request_handler.call_args[0][0]
+        self.assertEqual("connections/create", endpoint)
+
         self.assertEqual(
             os.environ["POSTGRES_BQ_CONNECTION"], "7aa68945-3e4b-4e1c-b504-2c36e5be2952"
         )
@@ -170,7 +175,18 @@ class AirbyteUtilsTest(unittest.TestCase):
     @patch("data_pipelines_cli.airbyte_utils.AirbyteFactory.request_handler")
     def test_update_connection(self, mock_run):
         mock_run.side_effect = [
-            {"connections": [{"connectionId": "7aa68945-3e4b-4e1c-b504-2c36e5be2952"}]},
+            {"workspaces": [{"workspaceId": "6e832a27-a146-46b6-9d0b-ca2fad5e476f"}]},
+            {
+                "connections": [
+                    {
+                        "connectionId": "7aa68945-3e4b-4e1c-b504-2c36e5be2952",
+                        "sourceId": "06a6f19f-b747-4672-a191-80b96f67c36e",
+                        "destinationId": "b3696ac3-93b2-4039-9021-e1f884b03a95",
+                        "namespaceFormat": "jaffle_shop",
+                        "namespaceDefinition": "customformat",
+                    }
+                ]
+            },
             {
                 "name": "POSTGRES_BQ_CONNECTION",
                 "connectionId": "7aa68945-3e4b-4e1c-b504-2c36e5be2952",
@@ -181,6 +197,17 @@ class AirbyteUtilsTest(unittest.TestCase):
         self.test_airbyte_factory.create_update_connection(
             self.airbyte_config["connections"]["POSTGRES_BQ_CONNECTION"]
         )
+
+        endpoint = mock_run.call_args[0][0]
+        self.assertEqual("connections/update", endpoint)
+
         self.assertEqual(
             os.environ["POSTGRES_BQ_CONNECTION"], "7aa68945-3e4b-4e1c-b504-2c36e5be2952"
         )
+
+
+#
+# "sourceId",
+# "destinationId",
+# "namespaceDefinition",
+# "namespaceFormat",

--- a/tests/test_airbyte_utils.py
+++ b/tests/test_airbyte_utils.py
@@ -1,5 +1,4 @@
 import copy
-import json
 import os
 import pathlib
 import tempfile
@@ -133,12 +132,12 @@ class AirbyteUtilsTest(unittest.TestCase):
                 call(
                     url=f"{self.airbyte_url}/api/v1/connections/search",
                     headers=headers,
-                    data=json.dumps(self.airbyte_config),
+                    json=self.airbyte_config,
                 ),
                 call(
                     url=f"{self.airbyte_url}/api/v1/connections/update",
                     headers=headers,
-                    data=json.dumps(self.airbyte_config),
+                    json=self.airbyte_config,
                 ),
             ],
             any_order=True,
@@ -204,10 +203,3 @@ class AirbyteUtilsTest(unittest.TestCase):
         self.assertEqual(
             os.environ["POSTGRES_BQ_CONNECTION"], "7aa68945-3e4b-4e1c-b504-2c36e5be2952"
         )
-
-
-#
-# "sourceId",
-# "destinationId",
-# "namespaceDefinition",
-# "namespaceFormat",

--- a/tests/test_airbyte_utils.py
+++ b/tests/test_airbyte_utils.py
@@ -218,6 +218,15 @@ class AirbyteUtilsTest(unittest.TestCase):
         self.assertEqual(os.environ["POSTGRES_BQ_CONNECTION"], matching_connection_id)
 
     @patch("data_pipelines_cli.airbyte_utils.AirbyteFactory.request_handler")
+    def test_get_default_workspace_id(self, mock_handler):
+        mock_handler.side_effect = (
+            {"workspaces": [{"workspaceId": "foo"}, {"workspaceId": "bar"}]},
+        )
+        self.test_airbyte_factory.airbyte_config.pop("workspace_id")
+
+        self.assertEqual(self.test_airbyte_factory.get_default_workspace_id(), "foo")
+
+    @patch("data_pipelines_cli.airbyte_utils.AirbyteFactory.request_handler")
     def test_missing_workspace_id_error_is_raised(self, mock_handler):
         mock_handler.side_effect = ({"workspaces": []},)
         self.test_airbyte_factory.airbyte_config.pop("workspace_id")

--- a/tests/test_airbyte_utils.py
+++ b/tests/test_airbyte_utils.py
@@ -178,16 +178,24 @@ class AirbyteUtilsTest(unittest.TestCase):
 
     @patch("data_pipelines_cli.airbyte_utils.AirbyteFactory.request_handler")
     def test_update_connection(self, mock_run):
+        matching_connection_id = "7aa68945-3e4b-4e1c-b504-2c36e5be2952"
         mock_run.side_effect = [
             {
                 "connections": [
                     {
-                        "connectionId": "7aa68945-3e4b-4e1c-b504-2c36e5be2952",
+                        "connectionId": "df1ac0ad-85c2-498e-a470-b4d106a0cdc7",
+                        "sourceId": "30f8c699-f7e3-4ac9-810f-639ffaec707e",
+                        "destinationId": "0ab4a08a-9467-43cc-b477-fb073c676cb5",
+                        "namespaceFormat": "public",
+                        "namespaceDefinition": "customformat",
+                    },
+                    {
+                        "connectionId": matching_connection_id,
                         "sourceId": "06a6f19f-b747-4672-a191-80b96f67c36e",
                         "destinationId": "b3696ac3-93b2-4039-9021-e1f884b03a95",
                         "namespaceFormat": "jaffle_shop",
                         "namespaceDefinition": "customformat",
-                    }
+                    },
                 ]
             },
             {
@@ -203,7 +211,9 @@ class AirbyteUtilsTest(unittest.TestCase):
         )
 
         endpoint = mock_run.call_args[0][0]
+        updated_connection_id = mock_run.call_args[0][1].get("connectionId")
         self.assertEqual("connections/update", endpoint)
+        self.assertEqual(matching_connection_id, updated_connection_id)
 
         self.assertEqual(
             os.environ["POSTGRES_BQ_CONNECTION"], "7aa68945-3e4b-4e1c-b504-2c36e5be2952"

--- a/tests/test_airbyte_utils.py
+++ b/tests/test_airbyte_utils.py
@@ -215,11 +215,9 @@ class AirbyteUtilsTest(unittest.TestCase):
         self.assertEqual("connections/update", endpoint)
         self.assertEqual(matching_connection_id, updated_connection_id)
 
-        self.assertEqual(
-            os.environ["POSTGRES_BQ_CONNECTION"], "7aa68945-3e4b-4e1c-b504-2c36e5be2952"
-        )
+        self.assertEqual(os.environ["POSTGRES_BQ_CONNECTION"], matching_connection_id)
 
-    def test_missing_worskpace_id_error_is_raised(self):
+    def test_missing_workspace_id_error_is_raised(self):
         self.test_airbyte_factory.airbyte_config.pop("workspace_id")
 
         with self.assertRaises(AirbyteConfigMissingWorkspaceIdError):

--- a/tests/test_airbyte_utils.py
+++ b/tests/test_airbyte_utils.py
@@ -57,8 +57,10 @@ class AirbyteUtilsTest(unittest.TestCase):
         connection_2_config = {"name": "connection_2_name"}
         task_1_config = {"api_version": "v1", "connection_id": "${CONNECTION_1_ID}"}
         task_2_config = {"api_version": "v2", "connection_id": "${CONNECTION_2_ID}"}
+        workspace_id = "35ac8060-b4da-4742-b5ba-16ce29dcf526"
         config = {
             "airbyte_url": self.airbyte_url,
+            "workspace_id": workspace_id,
             "connections": {
                 "connection_1": connection_1_config,
                 "connection_2": connection_2_config,
@@ -71,8 +73,8 @@ class AirbyteUtilsTest(unittest.TestCase):
             AirbyteFactory(pathlib.Path(tmp_file.name), None).create_update_connections()
             mock_create_update_connection.assert_has_calls(
                 [
-                    call(connection_1_config),
-                    call(connection_2_config),
+                    call(connection_config=connection_1_config, workspace_id=workspace_id),
+                    call(connection_config=connection_2_config, workspace_id=workspace_id),
                 ]
             )
             with open(tmp_file.name, "r") as f:
@@ -152,7 +154,6 @@ class AirbyteUtilsTest(unittest.TestCase):
     @patch("data_pipelines_cli.airbyte_utils.AirbyteFactory.request_handler")
     def test_create_connection(self, mock_request_handler):
         mock_request_handler.side_effect = [
-            {"workspaces": [{"workspaceId": "6e832a27-a146-46b6-9d0b-ca2fad5e476f"}]},
             {"connections": []},
             {
                 "name": "POSTGRES_BQ_CONNECTION",
@@ -161,7 +162,8 @@ class AirbyteUtilsTest(unittest.TestCase):
         ]
         # TODO
         self.test_airbyte_factory.create_update_connection(
-            self.airbyte_config["connections"]["POSTGRES_BQ_CONNECTION"]
+            connection_config=self.airbyte_config["connections"]["POSTGRES_BQ_CONNECTION"],
+            workspace_id=self.airbyte_config["workspace_id"],
         )
 
         endpoint = mock_request_handler.call_args[0][0]
@@ -174,7 +176,6 @@ class AirbyteUtilsTest(unittest.TestCase):
     @patch("data_pipelines_cli.airbyte_utils.AirbyteFactory.request_handler")
     def test_update_connection(self, mock_run):
         mock_run.side_effect = [
-            {"workspaces": [{"workspaceId": "6e832a27-a146-46b6-9d0b-ca2fad5e476f"}]},
             {
                 "connections": [
                     {
@@ -194,7 +195,8 @@ class AirbyteUtilsTest(unittest.TestCase):
             },
         ]
         self.test_airbyte_factory.create_update_connection(
-            self.airbyte_config["connections"]["POSTGRES_BQ_CONNECTION"]
+            connection_config=self.airbyte_config["connections"]["POSTGRES_BQ_CONNECTION"],
+            workspace_id=self.airbyte_config.get("workspace_id"),
         )
 
         endpoint = mock_run.call_args[0][0]

--- a/tests/test_airbyte_utils.py
+++ b/tests/test_airbyte_utils.py
@@ -9,8 +9,8 @@ import yaml
 from requests import HTTPError
 
 from data_pipelines_cli.airbyte_utils import (
-    AirbyteConfigMissingWorkspaceIdError,
     AirbyteFactory,
+    AirbyteNoWorkspaceConfiguredError,
 )
 
 
@@ -217,8 +217,10 @@ class AirbyteUtilsTest(unittest.TestCase):
 
         self.assertEqual(os.environ["POSTGRES_BQ_CONNECTION"], matching_connection_id)
 
-    def test_missing_workspace_id_error_is_raised(self):
+    @patch("data_pipelines_cli.airbyte_utils.AirbyteFactory.request_handler")
+    def test_missing_workspace_id_error_is_raised(self, mock_handler):
+        mock_handler.side_effect = ({"workspaces": []},)
         self.test_airbyte_factory.airbyte_config.pop("workspace_id")
 
-        with self.assertRaises(AirbyteConfigMissingWorkspaceIdError):
+        with self.assertRaises(AirbyteNoWorkspaceConfiguredError):
             self.test_airbyte_factory.create_update_connections()


### PR DESCRIPTION
Current implementation of AirbyteFactory uses `api/v1/connections/search` endpoint to test if connection with given `sourceId`, `destinationId`, `namespaceDefinition` and `namespaceFormat` exists. This endpoint does not return expected results: returned list is always empty, even if there is a connection matching the criteria, which results in creating a new connection every time.

We could use `api/v1/connections/list endpoint` to list all existing connections in workspace and check if connection with given parameters already exists.

Resolves `https://getindata.atlassian.net/browse/DATA-662`

---
Keep in mind:
- [x] Documentation updates
- [x] [Changelog](CHANGELOG.md) updates