### PR TITLE
Pin pydantic version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+-   Pinned Pydantic's version (transient dependency from Copier) as new major version breaks our CLI.
+
 ## [0.25.2] - 2023-06-16
 
 ### Fixed

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ INSTALL_REQUIREMENTS = [
     "packaging==21.3",
     "colorama==0.4.5",
     "dbt-core==1.3.1",
+    "pydantic<2",
 ]
 
 EXTRA_FILESYSTEMS_REQUIRE = {


### PR DESCRIPTION
`Copier` pinned Pydantic with `pydantic = ">=1.10.2"` which results in installation of new major version `2.0` which breaks our CLI (it's impossible to import `copier`). This PR adds `pydantic` to our setup file and ensures it's below `2.0`.

Resolves 

---
Keep in mind:
- [ ] Documentation updates
- [x ] [Changelog](CHANGELOG.md) updates